### PR TITLE
Use node.fs for reading content of directories in Electron apps

### DIFF
--- a/main.js
+++ b/main.js
@@ -66,19 +66,22 @@ function createWindow() {
 function registerListeners() {
     ipcMain.on('file-dialog', function (event) {
         dialog.showOpenDialog(mainWindow, {
+            filters: [
+                { name: 'ZIM Archives', extensions: ['zim', 'zimaa'] }
+              ],
             properties: ['openFile']
-        }).then(function (filePaths) {
+        }).then(function ({ filePaths }) {
             if (filePaths.length) {
-                event.reply('fileSelect', filePaths[0]);
+                event.reply('file-dialog', filePaths[0]);
             }
         });
     });
     ipcMain.on('dir-dialog', function (event) {
         dialog.showOpenDialog(mainWindow, {
             properties: ['openDirectory']
-        }).then(function (filePaths) {
+        }).then(function ({ filePaths }) {
             if (filePaths.length) {
-                event.reply('dirSelect', filePaths);
+                event.reply('dir-dialog', filePaths);
             }
         });
     })

--- a/main.js
+++ b/main.js
@@ -81,7 +81,7 @@ function registerListeners() {
             properties: ['openDirectory']
         }).then(function ({ filePaths }) {
             if (filePaths.length) {
-                event.reply('dir-dialog', filePaths);
+                event.reply('dir-dialog', filePaths[0]);
             }
         });
     })

--- a/main.js
+++ b/main.js
@@ -1,10 +1,5 @@
 // Modules to control application life and create native browser window
-const {
-    app,
-    protocol,
-    BrowserWindow,
-    shell
-} = require('electron');
+const { app, BrowserWindow } = require('electron');
 const path = require('path');
 
 const contextMenu = require('electron-context-menu');
@@ -47,14 +42,10 @@ contextMenu({
 //     }
 // }]);
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is garbage collected.
-let mainWindow;
-
 function createWindow() {
     // Create the browser window.
-    mainWindow = new BrowserWindow({
-        titleBarStyle: 'hidden',
+    const mainWindow = new BrowserWindow({
+        // titleBarStyle: 'hidden',
         width: 1281,
         height: 800,
         minWidth: 640,
@@ -62,67 +53,15 @@ function createWindow() {
         autoHideMenuBar: true,
         icon: path.join(__dirname, 'www/img/icons/kiwix-64.png'),
         webPreferences: {
-            nodeIntegration: false
-            // contextIsolation: true,
-            , preload: path.join(__dirname, 'preload.js')
+            preload: path.join(__dirname, 'preload.js')
             , nativeWindowOpen: true
-            // , webSecurity: false
-            // , session: ses
-            // , partition: 'persist:kiwixjs'
         }
     });
 
-    // and load the index.html of the app.
-    // mainWindow.loadURL(`https://${__dirname}/www/index.html`);
-    // mainWindow.loadURL(`https://pwa.kiwix.org/`);
-    // DEV: If you need Service Worker more than you need document.cookie, load app like this:
     mainWindow.loadFile('www/index.html');
-
-    //mainWindow.autoHideMenuBar = true;
-    
-    // mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    //     if (!/blob:/i.test(url)) {
-    //         return { action: 'allow' };
-    //     }
-    //     return { action: 'deny' };
-    // });
-
-    // mainWindow.webContents.on('new-window', function(e, url) {
-    //     // Make sure blob urls stay in electron perimeter
-    //     if(/^blob:/i.test(url)) {
-    //       return;
-    //     }
-    //     // And open every other protocol in the OS browser      
-    //     e.preventDefault();
-    //     shell.openExternal(url);
-    // });
-    
-    // DEV: Enable code below to check cookies saved by app in console log
-    // mainWindow.webContents.on('did-finish-load', function() {
-    //     mainWindow.webContents.session.cookies.get({}, (error, cookies) => {
-    //       console.log(cookies);
-    //     });
-    // });
-
-    // Open the DevTools.
-    // mainWindow.webContents.openDevTools()
-
-    // Emitted when the window is closed.
-    mainWindow.on('closed', function () {
-        // Dereference the window object, usually you would store windows
-        // in an array if your app supports multi windows, this is the time
-        // when you should delete the corresponding element.
-        mainWindow = null;
-    });
 }
 
-// let dirnameParts = __dirname.match(/[^\/\\]+(?:[\/\\]|$)/g);
-
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-
-app.on('ready', () => {
+app.whenReady().then(() => {
     // //protocol.registerFileProtocol('app', (request, callback) => {
     // protocol.registerHttpProtocol('app', (request, callback) => {
     //     const url = request.url.replace(/^app:\/\/([^?#]*?)([^?#\/\\]+)([#?].*$|$)/, function(_p0, relPath, linkUrl, hash) {
@@ -146,6 +85,13 @@ app.on('ready', () => {
     // });
     // Create the new window
     createWindow();
+
+    app.on('activate', function () {
+        // On macOS it's common to re-create a window in the app when the
+        // dock icon is clicked and there are no other windows open.
+        if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    });
+    
 });
 
 // Quit when all windows are closed.
@@ -154,12 +100,3 @@ app.on('window-all-closed', function () {
     // to stay active until the user quits explicitly with Cmd + Q
     if (process.platform !== 'darwin') app.quit();
 });
-
-app.on('activate', function () {
-    // On macOS it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    if (mainWindow === null) createWindow();
-});
-
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "maintainer": "Jaifroid",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "^15.3.0",
+    "electron": "^15.3.1",
     "electron-builder": "^22.13.1",
     "electron-packager": "^15.4.0"
   },
@@ -90,5 +90,3 @@
     "electron-context-menu": "^3.1.1"
   }
 }
-
-

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "kiwix-js-pwa",
-  "productName": "Kiwix JS PWA",
+  "name": "kiwix-js-electron",
+  "productName": "Kiwix JS Electron",
   "version": "1.7.8",
-  "description": "Kiwix JS PWA packaged for the Electron framework",
+  "description": "Kiwix JS packaged for the Electron framework",
   "main": "main.js",
   "build": {
-    "appId": "kiwix.js.pwa",
-    "productName": "Kiwix JS PWA",
+    "appId": "kiwix.js.electron",
+    "productName": "Kiwix JS Electron",
     "directories": {
       "output": "bld/Electron",
       "buildResources": "bld"
@@ -61,9 +61,9 @@
     "dist-win": "electron-builder build --win",
     "dist-linux": "electron-builder build --linux",
     "package-mac": "electron-packager . kiwix-js-windows --overwrite --platform=darwin --arch=x64 --icon=assets/icons/mac/icon.icns --prune=true --out=release-builds",
-    "package-win": "electron-packager . kiwix-js-windows --overwrite --electron-version='10.4.0' --ignore=archives --ignore=AppPackages --ignore=BundleArtifacts --ignore=images$ --ignore=bin$ --ignore=bld$ --ignore=KiwixWebApp.* --ignore=[pP]ackage.[aSl] --ignore=[.]git[hi][ug][bn] --ignore=[.]vs$ --ignore=vscode --platform=win32 --arch=ia32 --icon=www/img/icons/kiwix-64.ico --prune=true --out=bld/electron --version-string.CompanyName=Kiwix --version-string.FileDescription='Kiwix JS ZIM File Reader' --version-string.ProductName='Kiwix JS Windows Electron Edition'",
+    "package-win": "electron-packager . kiwix-js-windows --overwrite --electron-version='15.3.0' --ignore=archives --ignore=AppPackages --ignore=BundleArtifacts --ignore=images$ --ignore=bin$ --ignore=bld$ --ignore=KiwixWebApp.* --ignore=[pP]ackage.[aSl] --ignore=[.]git[hi][ug][bn] --ignore=[.]vs$ --ignore=vscode --platform=win32 --arch=ia32 --icon=www/img/icons/kiwix-64.ico --prune=true --out=bld/electron --version-string.CompanyName=Kiwix --version-string.FileDescription='Kiwix JS ZIM File Reader' --version-string.ProductName='Kiwix JS Windows Electron Edition'",
     "postpackage-win": "(robocopy archives bld\\Electron\\kiwix-js-windows-win32-ia32\\resources\\app\\archives\\ > null) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0",
-    "package-linux": "electron-packager . kiwix-js-windows --overwrite --platform=linux --icon=www/img/icons/kiwix-64.png --electron-version='10.4.0' --ignore=archives --ignore=AppPackages --ignore=BundleArtifacts --ignore=images$ --ignore=bin$ --ignore=bld$ --ignore=KiwixWebApp.* --ignore=[pP]ackage.[aSl] --ignore=[.]git[hi][ug][bn] --ignore=[.]vs$ --ignore=vscode --arch=x64 --prune=true --out=bld/electron --version-string.CompanyName=Kiwix --version-string.FileDescription='Kiwix JS ZIM File Reader' --version-string.ProductName='Kiwix JS Windows Electron Edition'",
+    "package-linux": "electron-packager . kiwix-js-windows --overwrite --platform=linux --icon=www/img/icons/kiwix-64.png --electron-version='15.3.0' --ignore=archives --ignore=AppPackages --ignore=BundleArtifacts --ignore=images$ --ignore=bin$ --ignore=bld$ --ignore=KiwixWebApp.* --ignore=[pP]ackage.[aSl] --ignore=[.]git[hi][ug][bn] --ignore=[.]vs$ --ignore=vscode --arch=x64 --prune=true --out=bld/electron --version-string.CompanyName=Kiwix --version-string.FileDescription='Kiwix JS ZIM File Reader' --version-string.ProductName='Kiwix JS Windows Electron Edition'",
     "postpackage-linux": "(robocopy archives bld\\Electron\\kiwix-js-windows-linux-x64\\archives\\ > null) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL = 0"
   },
   "repository": "https://github.com/kiwix/kiwix-js-windows",
@@ -81,9 +81,9 @@
   "maintainer": "Jaifroid",
   "license": "CC0-1.0",
   "devDependencies": {
-    "electron": "^10.4.0",
-    "electron-builder": "^22.11.7",
-    "electron-packager": "^15.2.0"
+    "electron": "^15.3.0",
+    "electron-builder": "^22.13.1",
+    "electron-packager": "^15.4.0"
   },
   "dependencies": {
     "@types/fs-extra": "^9.0.11",

--- a/preload.js
+++ b/preload.js
@@ -26,7 +26,7 @@ contextBridge.exposeInMainWorld('dialog', {
         ipcRenderer.send('dir-dialog'); // adjust naming for your project
     },
     // Provide an easier way to listen to events
-    on: (channel, callback) => {
+    on: function (channel, callback) {
       ipcRenderer.on(channel, function (_, data) {
           callback(data);
         });

--- a/preload.js
+++ b/preload.js
@@ -4,8 +4,7 @@
 'use strict';
 
 // DEV: TO SUPPORT ELECTRON ^12 YOU WILL NEED THIS
-const { contextBridge } = require('electron');
-
+const { ipcRenderer, contextBridge } = require('electron');
 const { open, read, close, stat } = require('fs');
 
 console.log("Inserting required Electron functions into DOM...");
@@ -18,12 +17,22 @@ contextBridge.exposeInMainWorld('fs', {
     stat: stat
 });
 
-// window.fs = {
-//     open: open, 
-//     read: read,
-//     close: close, 
-//     stat: stat
-// };
+// Adapted from: https://stackoverflow.com/questions/69717365/using-electron-save-dialog-in-renderer-with-context-isolation
+contextBridge.exposeInMainWorld('dialog', {
+    openFile: function () {
+      ipcRenderer.send('file-dialog'); // adjust naming for your project
+    },
+    openDirectory: function () {
+        ipcRenderer.send('dir-dialog'); // adjust naming for your project
+    },
+    // Provide an easier way to listen to events
+    on: (channel, callback) => {
+      ipcRenderer.on(channel, function (_, data) {
+          callback(data);
+        });
+    },
+  });
+
 // window.Buffer = Buffer;
 
 // console.log(win.session.cookies);

--- a/preload.js
+++ b/preload.js
@@ -4,25 +4,26 @@
 'use strict';
 
 // DEV: TO SUPPORT ELECTRON ^12 YOU WILL NEED THIS
-// const { contextBridge } = require('electron');
+const { contextBridge } = require('electron');
+
 const { open, read, close, stat } = require('fs');
 
 console.log("Inserting required Electron functions into DOM...");
 
 // DEV: FOR ELECTRON ^12 DO IT THIS WAY:
-// contextBridge.exposeInMainWorld('fs', {
-//     open: open, 
-//     read: read,
-//     close: close, 
-//     stat: stat
-// });
-
-window.fs = {
+contextBridge.exposeInMainWorld('fs', {
     open: open, 
     read: read,
     close: close, 
     stat: stat
-};
+});
+
+// window.fs = {
+//     open: open, 
+//     read: read,
+//     close: close, 
+//     stat: stat
+// };
 // window.Buffer = Buffer;
 
 // console.log(win.session.cookies);
@@ -30,16 +31,4 @@ window.fs = {
 // win.session.cookies.get({}, (error, cookies) => {
 //     console.log(cookies);
 // });
-
-
-// window.addEventListener('DOMContentLoaded', () => {
-//     const replaceText = (selector, text) => {
-//       const element = document.getElementById(selector)
-//       if (element) element.innerText = text;
-//     } 
-    
-//     for (const type of ['chrome', 'node', 'electron']) {
-//       replaceText(`${type}-version`, process.versions[type]);
-//     }
-//   });
 

--- a/preload.js
+++ b/preload.js
@@ -5,7 +5,7 @@
 
 // DEV: TO SUPPORT ELECTRON ^12 YOU WILL NEED THIS
 const { ipcRenderer, contextBridge } = require('electron');
-const { open, read, close, stat } = require('fs');
+const { open, read, close, stat, readdir } = require('fs');
 
 console.log("Inserting required Electron functions into DOM...");
 
@@ -13,6 +13,7 @@ console.log("Inserting required Electron functions into DOM...");
 contextBridge.exposeInMainWorld('fs', {
     open: open, 
     read: read,
+    readdir: readdir,
     close: close, 
     stat: stat
 });

--- a/www/index.html
+++ b/www/index.html
@@ -635,10 +635,10 @@
                             <div id="openLocalFiles" style="display: block;">
                                 <div class="row">
                                     <div class="col-xs-6">
-                                        <input type="button" class="btn btn-primary" value="Select file" id="archiveFile" accept=".zim" />
+                                        <input type="button" class="btn btn-primary" value="Select file" id="archiveFile" />
                                     </div>
                                     <div class="col-xs-6">
-                                        <input type="button" class="btn btn-primary" value="Select folder" id="archiveFiles" accept=".zim,.dat,.idx,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz, .zimba, .zimbb, .zimbc, .zimbd, .zimbe, .zimbf, .zimbg, .zimbh, .zimbi, .zimbj, .zimbk, .zimbl, .zimbm, .zimbn, .zimbo, .zimbp, .zimbq, .zimbr, .zimbs, .zimbt, .zimbu, .zimbv, .zimbw, .zimbx, .zimby, .zimbz" />
+                                        <input type="button" class="btn btn-primary" value="Select folder" id="archiveFiles" />
                                     </div>
                                 </div>
                                 <div id="UWPInstructions" class="row">

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2886,12 +2886,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
             var file = {};
             // For Electron, we need to set an absolute filepath in case the file was launched from a shortcut (and if it's not already absolute)
             if (filepath === params.archivePath + '/' + filename && /^file:/i.test(window.location.protocol)) {
-                filepath = window.location.href.replace(/www\/[^/?#]+(?:[?#].*)?$/, '') + filepath;
+                filepath = decodeURIComponent(window.location.href.replace(/www\/[^/?#]+(?:[?#].*)?$/, '') + filepath);
             }
             // DEV if you get pesky Electron error 'The "path" argument must be one of type string, Buffer, or URL', try commenting below
             // if (/^file:/i.test(filepath)) filepath = new URL(filepath);
             // and uncomment comment line below (seems to depend on node and fs versions) - this line conditionally turns the URL into a filepath string for Windows only
-            filepath = /^file:\/+\w:/i.test(filepath) ? filepath.replace(/^file:\/+/i, '') : filepath;
+            filepath = /^file:\/+\w:[/\\]/i.test(filepath) ? filepath.replace(/^file:\/+/i, '') : filepath.replace(/^file:\/\//i, '');
             file.name = filename;
             file.path = filepath;
             file.readMode = 'electron';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2766,6 +2766,12 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
         }
 
         function setLocalArchiveFromFileList(files) {
+            if (!files.length) {
+                if (document.getElementById('configuration').style.display == 'none')
+                        document.getElementById('btnConfigure').click();
+                displayFileSelect();
+                return;
+            }
             // Check for usable file types
             for (var i = files.length; i--;) {
                 // DEV: you can support other file types by adding (e.g.) '|dat|idx' after 'zim\w{0,2}'
@@ -2900,6 +2906,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
                 if (err) {
                     file.size = null;
                     console.error('File cannot be found!', err);
+                    uiUtil.systemAlert('The archive you are attempting to load (' + file.path + ') cannot be found. Perhaps it has moved?');
+                    callback([]);
                 } else {
                     file.size = stats.size;
                     console.log("Stored file size is: " + file.size);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2289,7 +2289,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
          */
         function setLocalArchiveFromArchiveList(archive) {
             params.rescan = false;
-            archive = archive || [$('#archiveList').val()];
+            archive = archive || $('#archiveList').val();
             if (archive && archive.length > 0) {
                 // Now, try to find which DeviceStorage has been selected by the user
                 // It is the prefix of the archive directory
@@ -2573,7 +2573,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
             packet.preventDefault();
             configDropZone.style.border = '';
             var items = packet.dataTransfer.items;
-            if (items && items[0].kind === 'file' && typeof items[0].getAsFileSystemHandle !== 'undefined') {
+            if (items && items.length === 1 && items[0].kind === 'file' && typeof items[0].getAsFileSystemHandle !== 'undefined') {
                 items[0].getAsFileSystemHandle().then(function (handle) {
                     if (handle.kind === 'file') {
                         processNativeFileHandle(handle);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2464,12 +2464,18 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
                                                 }
                                                 setTimeout(testIfReady, 50);
                                             } else {
-                                                console.error("There was an error reading the picked file(s)!");
+                                                console.error('There was an error reading the picked file(s)!');
                                             }
                                         } else {
                                             createFakeFileObjectElectron(fileHandle, params.pickedFolder + '/' + fileHandle, setLocalArchiveFromFileList);
                                         } 
                                     });
+                                } else {
+                                    uiUtil.systemAlert('We could not find the location of the file ' + fileHandle + 
+                                        '. This can happen if you dragged and dropped a file into the app. Please use the file or folder pickers instead.');
+                                    if (document.getElementById('configuration').style.display == 'none')
+                                        document.getElementById('btnConfigure').click();
+                                    displayFileSelect();
                                 }
                             }
                             return;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -991,7 +991,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
             if (params.pickedFile && params.pickedFile.name !== selected) {
                 params.pickedFile = '';
             }
-            if (params.pickedFile.readMode !== 'electron' && typeof window.showOpenFilePicker !== 'undefined') {
+            if (typeof window.showOpenFilePicker !== 'undefined') {
                 getNativeFSHandle(function(handle) {
                     if (!handle) {
                         console.error('No handle was retrieved');
@@ -2627,6 +2627,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
                             if (callback) archiveList.push(entry);
                             // Hide all parts of split file except first in UI
                             else if (/\.zim(aa)?$/.test(entry.name)) archiveList.push(entry.name);
+                            if (!params.pickedFolder.path) entry.getFile().then(function(file) {
+                                params.pickedFolder.path = file.path;
+                            })
                         }
                         iterateAsyncDirEntryArray();
                     } else {
@@ -2837,9 +2840,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
                 filepath = window.location.href.replace(/www\/[^/]+$/, '') + filepath;
             }
             // DEV if you get pesky Electron error 'The "path" argument must be one of type string, Buffer, or URL', try commenting below
-            if (/^file:/i.test(filepath)) filepath = new URL(filepath);
+            // if (/^file:/i.test(filepath)) filepath = new URL(filepath);
             // and uncomment comment line below (seems to depend on node and fs versions) - this line conditionally turns the URL into a filepath string for Windows only
-            // filepath = /^file:\/+\w:/i.test(filepath) ? filepath.replace(/^file:\/+/i, '') : filepath = new URL(filepath);
+            filepath = /^file:\/+\w:/i.test(filepath) ? filepath.replace(/^file:\/+/i, '') : filepath = new URL(filepath);
             file.name = filename;
             file.path = filepath;
             file.readMode = 'electron';

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -308,6 +308,10 @@ if (params.storedFile && typeof Windows !== 'undefined' && typeof Windows.Storag
     }
 }
 
+if (window.fs && !window.nw) {
+    params.pickedFolder = getSetting('pickedFolder') || '';
+}
+
 // Routine for installing the app adapted from https://pwa-workshop.js.org/
 
 var deferredPrompt;

--- a/www/js/lib/cache.js
+++ b/www/js/lib/cache.js
@@ -654,6 +654,7 @@ define(['settingsStore', 'uiUtil'], function(settingsStore, uiUtil) {
      * @returns {Promise<Boolean>} A Promise for a Boolean value indicating whether permission has been granted or not
      */    
     function verifyPermission(fileHandle, withWrite) {
+        if (window.fs) return Promise.resolve(true); // Electron
         var opts = withWrite ? { mode: 'readwrite' } : {};
         return fileHandle.queryPermission(opts).then(function(permission) {
             if (permission === "granted") return true;


### PR DESCRIPTION
This PR fixes #206. It also enhances file picking with Electron. In sum, the PR:

* Updates API usage so that Kiwix JS Electron can run on the latest Electron builds;
* Modernizes the file and directory picking in the Electron app, so that it has equivalent functionality to the UWP, PWA and NWJS apps. In other words, the user can now pick a directory of ZIM archives, and the app will list all of the archives, allowing the user to select amongst them by clicking on each archive name;
* Provides graceful return to Configuration and file selectors if a previously picked archive can no longer be found.

NWJS provides this functionality "natively" via the File System Access API, which it hacks so that the user does not have to give permission for the installed app to access files and directories (after the file or directory has previously been picked). Unfortunately, Electron has so far only partially implemented the File System Access API (see https://github.com/electron/electron/issues/28422) and there is no sign of interest in fixing it. Hence it is necessary to use Electron-specific (Node) APIs to access the FS.

TODO:

* The final thing to do is provide access to split archive parts in a folder, so the user only has to select one part, and the rest are automatically selected (this is supported in the UWP, PWA and NWJS apps).