### PR TITLE
Trap mouse forward and back buttons in UWP app

### DIFF
--- a/KiwixWebApp.jsproj
+++ b/KiwixWebApp.jsproj
@@ -72,7 +72,7 @@
     <PackageCertificateKeyFile>KiwixWebApp_StoreKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="archives\wikipedia_en_100_nopic_2021-10.zim" />
+    <Content Include="archives\wikipedia_en_100_nopic_2021-11.zim" />
     <Content Include="images\BadgeLogo.scale-100.png" />
     <Content Include="images\BadgeLogo.scale-125.png" />
     <Content Include="images\BadgeLogo.scale-150.png" />
@@ -140,7 +140,6 @@
     <Content Include="www\-\mw\ext.tmh.thumbnail.styles.css" />
     <Content Include="www\-\mw\inserted_style.css" />
     <Content Include="www\-\mw\inserted_style_mobile.css" />
-    <Content Include="www\-\mw\inserted_style_original.css" />
     <Content Include="www\-\mw\mediawiki.action.view.redirectPage.css" />
     <Content Include="www\-\mw\mediawiki.page.gallery.styles.css" />
     <Content Include="www\-\mw\mediawiki.toc.css" />
@@ -152,7 +151,6 @@
     <Content Include="www\-\mw\mw.PopUpMediaTransform.css" />
     <Content Include="www\-\mw\mw.TMHGalleryHook.js.css" />
     <Content Include="www\-\mw\newstyle_main_page.css" />
-    <Content Include="www\-\mw\original-inserted_style_mobile.css" />
     <Content Include="www\-\mw\style.css" />
     <Content Include="www\-\style.css" />
     <Content Include="www\A\Main_Page" />

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -168,6 +168,17 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
             btnRandomAlt.style.display = 'inline';
         }
 
+        window.addEventListener('click', function (e) {
+            if (typeof e === 'object') {
+                if (e.button === 3) {
+                    document.getElementById('btnBack').click();
+                }
+                if (e.button === 4) {
+                    document.getElementById('btnForward').click();
+                }
+            }
+        });
+        
         var searchArticlesFocused = false;
         document.getElementById('searchArticles').addEventListener('click', function () {
             var prefix = document.getElementById('prefix').value;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -168,7 +168,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
             btnRandomAlt.style.display = 'inline';
         }
 
-        window.addEventListener('click', function (e) {
+        // Process pointerup events (used for checking if mouse back / forward buttons have been clicked)
+        function onPointerUp(e) {
             if (typeof e === 'object') {
                 if (e.button === 3) {
                     document.getElementById('btnBack').click();
@@ -177,7 +178,9 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
                     document.getElementById('btnForward').click();
                 }
             }
-        });
+        }
+
+        if (/UWP/.test(params.appType)) document.body.addEventListener('pointerup', onPointerUp);
         
         var searchArticlesFocused = false;
         document.getElementById('searchArticles').addEventListener('click', function () {
@@ -4214,6 +4217,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
                     if (params.allowHTMLExtraction && appstate.target === 'iframe') {
                         uiUtil.insertBreakoutLink(determinedTheme);
                     }
+                    // Trap any clicks on the iframe to detect if mouse back or forward buttons have been pressed (Chromium does this natively)
+                    if (/UWP/.test(params.appType)) docBody.addEventListener('pointerup', onPointerUp);
                     // Document has loaded except for images, so we can now change the startup cookie (and delete) [see init.js]
                     // document.cookie = 'lastPageLoad=success;expires=Thu, 21 Sep 1979 00:00:01 UTC';
                     settingsStore.removeItem('lastPageLoad');

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3470,6 +3470,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'cache', 'images', 'sett
                     var determinedTheme = params.cssTheme == 'auto' ? cssUIThemeGetOrSet('auto') : params.cssTheme;
                     uiUtil.insertBreakoutLink(determinedTheme);
                 }
+                // Trap any clicks on the iframe to detect if mouse back or forward buttons have been pressed (Chromium does this natively)
+                if (/UWP/.test(params.appType)) docBody.addEventListener('pointerup', onPointerUp);
                 // The content is ready : we can hide the spinner
                 setTab();
                 setTimeout(function() {


### PR DESCRIPTION
This PR fixes #214. It is only needed in the UWP app because it is handled natively by browsers and by PWAs. Also by Chromium, therefore by Electron and (although I haven't yet tested it) by NWJS.