### PR TITLE
Trigger webapp restart

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -36,3 +36,9 @@ jobs:
           restrict-to: kiwix/kiwix-js-windows
           registries: docker.io
           manual-tag: ${{ github.event.inputs.version }}
+      - name: Restart live webapp
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: rollout restart deployments pwa-deployment -n pwa

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -24,17 +24,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build and push
-        uses: openzim/docker-publish-action@v5
+        uses: openzim/docker-publish-action@v8
         with:
           image-name: kiwix/kiwix-pwa
           credentials: |
-            DOCKERIO_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
-            DOCKERIO_TOKEN=${{ secrets.DOCKERHUB_PASSWORD }}
+            GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
+            GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}
           tag-pattern: /^v([0-9.]+).*$/
           latest-on-tag: true
           dockerfile: Dockerfile.pwa
           restrict-to: kiwix/kiwix-js-windows
-          registries: docker.io
+          registries: ghcr.io
           manual-tag: ${{ github.event.inputs.version }}
       - name: Restart live webapp
         uses: actions-hub/kubectl@master


### PR DESCRIPTION
Note: This app's hosting has already been migrated to our new (k8s-based) hosting. We can discuss different ways to offer this feature but as of now, your app is not reloading automatically on image pushes.

Manually trigger a *restart* on Kiwix k8s after a successful image push.
Previous behavior was to let Docker Hub trigger a restart on (former) hosting via a webhook:
- we don't want to rely on Docker Hub anymore
- hosting platform changed