### PR TITLE
Fixed build uploads

### DIFF
--- a/scripts/Publish-ElectronPackages.ps1
+++ b/scripts/Publish-ElectronPackages.ps1
@@ -123,7 +123,7 @@ if (-not $CRON_LAUNCHED) {
 
 if (-not $githubonly) {
     "`nUploading packages to https://download.kiwix.org$target/ ...`n"
-    & "C:\Program Files\Git\usr\bin\ssh.exe" @('-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'ci@download.kiwix.org', "mkdir -p $target")
+    echo "mkdir $target" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'ci@master.download.kiwix.org')
 
     $Packages | % {
         $file = $_
@@ -163,7 +163,7 @@ if (-not $githubonly) {
                 # Replace absolute path with relative, and normalize to forward slashes
                 $renamed_file = $renamed_file -replace '^.*?([\\/]bld)', '.$1' -replace '[\\/]', '/'
                 "Copying $renamed_file to $target..."
-                & "C:\Program Files\Git\usr\bin\scp.exe" @('-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$renamed_file", "ci@download.kiwix.org:$target")
+                & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$renamed_file", "ci@master.download.kiwix.org:$target")
             }
         }
     }

--- a/scripts/Push-KiwixRelease.ps1
+++ b/scripts/Push-KiwixRelease.ps1
@@ -56,15 +56,15 @@ function Main {
         $keyfile = "$PSScriptRoot\ssh_key"
         $keyfile = $keyfile -ireplace '[\\/]', '/'
         if ($dryrun) {
-            "C:\Program Files\Git\usr\bin\scp.exe -o StrictHostKeyChecking=no -i $keyfile $filename ci@download.kiwix.org:$target"
-            "C:\Program Files\Git\usr\bin\ssh.exe -o StrictHostKeyChecking=no -i $keyfile ci@download.kiwix.org mv $target/$file $target/$newfilename"  
+            "C:\Program Files\Git\usr\bin\scp.exe -P 30022 -o StrictHostKeyChecking=no -i $keyfile $filename ci@master.download.kiwix.org:$target"
+            "echo 'rename $target/$file $target/$newfilename' | C:\Program Files\Git\usr\bin\sftp.exe -P 30022 -o StrictHostKeyChecking=no -i $keyfile ci@master.download.kiwix.org"
             "Aborting because this is a dry run."
             exit
         }
         # Uploading file
         # Move-Item $filename $originalpath/$newfilename
-        & "C:\Program Files\Git\usr\bin\scp.exe" @('-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$filename", "ci@download.kiwix.org:$target")
-        & "C:\Program Files\Git\usr\bin\ssh.exe" @('-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'ci@download.kiwix.org', "mv $target/$file $target/$newfilename")
+        & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$filename", "ci@master.download.kiwix.org:$target")
+        echo "rename $target/$file $target/$newfilename" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'ci@master.download.kiwix.org')
         "Done."
     } else {
         "You can only upload a file of type .appx, .appxbundle or .appxupload"

--- a/scripts/publish_linux_packages_to_kiwix.sh
+++ b/scripts/publish_linux_packages_to_kiwix.sh
@@ -10,7 +10,7 @@ if [[ "qq${CRON_LAUNCHED}" != "qq" ]]; then
     target="/data/download/nightly/$CURRENT_DATE"
 fi
 echo "Uploading packages to https://download.kiwix.org$target/"
-ssh -o StrictHostKeyChecking=no -i ./scripts/ssh_key ci@download.kiwix.org mkdir -p $target
+echo "mkdir ${target}" | sftp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key ci@master.download.kiwix.org
 for file in ./bld/Electron/* ; do
     if [[ "$file" =~ \.(AppImage|deb|rpm)$ ]]; then
         directory=$(sed -E 's/[^\/]+$//' <<<"$file")
@@ -44,6 +44,6 @@ for file in ./bld/Electron/* ; do
             mv "$file" "$renamed_file"
         fi
         echo "Copying $renamed_file to $target"
-        scp -o StrictHostKeyChecking=no -i ./scripts/ssh_key "$renamed_file" ci@download.kiwix.org:$target
+        scp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key "$renamed_file" ci@master.download.kiwix.org:$target
     fi
 done


### PR DESCRIPTION
Changes the destination of uploads to master.download.kiwix.org on port 30022
As this service doesn't offer a shell anymore, converted the folder creation
and file renaming to more verbose, SFTP-based scripts.