### PR TITLE
Experiment with enabling embedded video for zimit

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -283,8 +283,8 @@ let fetchCaptureEnabled = false;
  * Intercept selected Fetch requests from the browser window
  */
 self.addEventListener('fetch', function (event) {
-    // Only cache GET requests
-    if (event.request.method !== "GET") return;
+    // Only handle GET or POST requests (POST is intended to handle video in Zimit ZIMs)
+    if (!/GET|POST/.test(event.request.method)) return;
     var rqUrl = event.request.url;
     var urlObject = new URL(rqUrl);
     // Test the URL with parameters removed

--- a/service-worker.js
+++ b/service-worker.js
@@ -369,7 +369,7 @@ self.addEventListener('fetch', function (event) {
             fetchCaptureEnabled = true;
         } else if (event.data.action === 'disable') {
             // On 'disable' message, we delete the outgoingMessagePort and disable the fetchEventListener
-            outgoingMessagePort = null;
+            // outgoingMessagePort = null;
             fetchCaptureEnabled = false;
         }
         var oldValue;

--- a/service-worker.js
+++ b/service-worker.js
@@ -310,7 +310,8 @@ self.addEventListener('fetch', function (event) {
         }, function () {
             // The response was not found in the cache so we look for it in the ZIM
             // and add it to the cache if it is an asset type (css or js)
-            if (cache === ASSETS_CACHE && regexpZIMUrlWithNamespace.test(strippedUrl)) {
+            // YouTube links from Zimit archives are dealt with specially
+            if (/youtubei.*player/.test(strippedUrl) || cache === ASSETS_CACHE && regexpZIMUrlWithNamespace.test(strippedUrl)) {
                 let range = event.request.headers.get('range');
                 if (imageDisplay !== 'all' && /\/.*\.(jpe?g|png|svg|gif|webp)(?=.*?kiwix-display)/i.test(rqUrl)) {
                     // If the user has disabled the display of images, and the browser wants an image, respond with empty SVG
@@ -409,9 +410,9 @@ function fetchUrlFromZIM(urlObject, range) {
         // Be sure that you haven't encoded any querystring along with the URL.
         var barePathname = decodeURIComponent(urlObject.pathname);
         var partsOfZIMUrl = regexpZIMUrlWithNamespace.exec(barePathname);
-        var prefix = partsOfZIMUrl[1];
-        var nameSpace = partsOfZIMUrl[2];
-        var title = partsOfZIMUrl[3];
+        var prefix = partsOfZIMUrl ? partsOfZIMUrl[1] : '';
+        var nameSpace = partsOfZIMUrl ? partsOfZIMUrl[2]: '';
+        var title = partsOfZIMUrl ? partsOfZIMUrl[3] : barePathname;
         var anchorTarget = urlObject.hash.replace(/^#/, '');
         var uriComponent = urlObject.search.replace(/\?kiwix-display/, '');
         var titleWithNameSpace = nameSpace + '/' + title;

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -107,6 +107,7 @@ div:not(.panel-success, .alert-message) {
 
 #articleList {
     margin-bottom: 12px !important;
+    overflow-wrap: break-word;
 }
 
 #scrollbox {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4038,15 +4038,6 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                             return m1.replace(/[&]/g, '%26').replace(/,/g, '%2C') + (m2 || '');
                             // return encodeURI(m1) + (m2 || '');
                         });
-                        // Do any video transformations
-                        // transformZimit.transformVideoUrl(title, function (dirEntry) {
-                        //     appstate.selectedArchive.getDirEntryByPath(transformedTitle).then(function (dirEntry) {
-                        //         if (dirEntry) dirEntry.isAsset = titleIsAsset;
-                        //         return readFile(dirEntry);
-                        //     }).catch(function (err) {
-                        //         console.error('Failed to read ' + transformedTitle, err);
-                        //     });
-                        // });
                     }
                     appstate.selectedArchive.getDirEntryByPath(title).then(function (dirEntry) {
                         if (dirEntry) dirEntry.isAsset = titleIsAsset;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3976,7 +3976,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                                 uiUtil.pollSpinner('Getting ' + shortTitle + '...');
                             }
                             // If it's an HTML type and not an asset, we load it in a new page instance
-                            if (/\bx?html\b/i.test(mimetype) && !dirEntry.isAsset) {
+                            if (/\bx?html\b/i.test(mimetype) && !dirEntry.isAsset && !/\.(png|gif|jpe?g|css|js|mpe?g|mp4|webp|webm|woff2?)(\?|$)/i.test(dirEntry.url)) {
                                 loadingArticle = title;
                                 // Intercept files of type html and apply transformations
                                 var message = {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4033,27 +4033,26 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                         }
                     };
                     if (params.zimType === 'zimit') {
-                        // Do any fuzzy transformations
-                        if (/youtube|googlevideo/i.test(title)) {
-                            title = transformZimit.transformFuzzyUrl(title);
-                        }
                         title = title.replace(/^([^?]+)(\?[^?]*)?$/, function (m0, m1, m2) {
                             // Note that Zimit ZIMs store ZIM URLs encoded, but SOME incorrectly encode using encodeURIComponent, instead of encodeURI!
                             return m1.replace(/[&]/g, '%26').replace(/,/g, '%2C') + (m2 || '');
                             // return encodeURI(m1) + (m2 || '');
                         });
-                    };
-                    appstate.selectedArchive.getDirEntryByPath(title).then(function (dirEntry) {
-                        if (dirEntry) dirEntry.isAsset = titleIsAsset;
-                        return readFile(dirEntry);
-                    }).catch(function (err) {
-                        console.error('Failed to read ' + title, err);
-                        messagePort.postMessage({
-                            'action': 'giveContent',
-                            'title': title,
-                            'content': new Uint8Array
+                        // Do any video transformations
+                        transformZimit.transformVideoUrl(title, function (transformedTitle) {
+                            appstate.selectedArchive.getDirEntryByPath(transformedTitle).then(function (dirEntry) {
+                                if (dirEntry) dirEntry.isAsset = titleIsAsset;
+                                return readFile(dirEntry);
+                            }).catch(function (err) {
+                                console.error('Failed to read ' + transformedTitle, err);
+                                messagePort.postMessage({
+                                    'action': 'giveContent',
+                                    'title': title,
+                                    'content': new Uint8Array
+                                });
+                            });
                         });
-                    });
+                    };
                 } else {
                     console.error("Invalid message received", event.data);
                 }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -26,8 +26,8 @@
 // This uses require.js to structure javascript:
 // http://requirejs.org/docs/api.html#define
 
-define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images', 'settingsStore', 'transformStyles', 'kiwixServe', 'updater'],
-    function ($, zimArchiveLoader, uiUtil, util, utf8, cache, images, settingsStore, transformStyles, kiwixServe, updater) {
+define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images', 'settingsStore', 'transformStyles', 'transformZimit', 'kiwixServe', 'updater'],
+    function ($, zimArchiveLoader, uiUtil, util, utf8, cache, images, settingsStore, transformStyles, transformZimit, kiwixServe, updater) {
 
         /**
          * The delay (in milliseconds) between two "keepalive" messages
@@ -4033,11 +4033,15 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                         }
                     };
                     if (params.zimType === 'zimit') {
+                        // Do any fuzzy transformations
+                        if (/youtube|googlevideo/i.test(title)) {
+                            title = transformZimit.transformFuzzyUrl(title);
+                        }
                         title = title.replace(/^([^?]+)(\?[^?]*)?$/, function (m0, m1, m2) {
                             // Note that Zimit ZIMs store ZIM URLs encoded, but SOME incorrectly encode using encodeURIComponent, instead of encodeURI!
                             return m1.replace(/[&]/g, '%26').replace(/,/g, '%2C') + (m2 || '');
                             // return encodeURI(m1) + (m2 || '');
-                        })
+                        });
                     };
                     appstate.selectedArchive.getDirEntryByPath(title).then(function (dirEntry) {
                         if (dirEntry) dirEntry.isAsset = titleIsAsset;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4032,13 +4032,10 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                             });
                         }
                     };
-                    if (params.zimType === 'zimit') {
-                        title = title.replace(/^([^?]+)(\?[^?]*)?$/, function (m0, m1, m2) {
-                            // Note that Zimit ZIMs store ZIM URLs encoded, but SOME incorrectly encode using encodeURIComponent, instead of encodeURI!
-                            return m1.replace(/[&]/g, '%26').replace(/,/g, '%2C') + (m2 || '');
-                            // return encodeURI(m1) + (m2 || '');
-                        });
-                    }
+                    if (params.zimType === 'zimit') title = title.replace(/^([^?]+)(\?[^?]*)?$/, function (m0, m1, m2) {
+                        // Note that Zimit ZIMs store ZIM URLs encoded, but SOME incorrectly encode using encodeURIComponent, instead of encodeURI!
+                        return m1.replace(/[&]/g, '%26').replace(/,/g, '%2C') + (m2 || '');
+                    });
                     appstate.selectedArchive.getDirEntryByPath(title).then(function (dirEntry) {
                         if (dirEntry) dirEntry.isAsset = titleIsAsset;
                         return readFile(dirEntry);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4039,20 +4039,26 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                             // return encodeURI(m1) + (m2 || '');
                         });
                         // Do any video transformations
-                        transformZimit.transformVideoUrl(title, function (transformedTitle) {
-                            appstate.selectedArchive.getDirEntryByPath(transformedTitle).then(function (dirEntry) {
-                                if (dirEntry) dirEntry.isAsset = titleIsAsset;
-                                return readFile(dirEntry);
-                            }).catch(function (err) {
-                                console.error('Failed to read ' + transformedTitle, err);
-                                messagePort.postMessage({
-                                    'action': 'giveContent',
-                                    'title': title,
-                                    'content': new Uint8Array
-                                });
-                            });
+                        // transformZimit.transformVideoUrl(title, function (dirEntry) {
+                        //     appstate.selectedArchive.getDirEntryByPath(transformedTitle).then(function (dirEntry) {
+                        //         if (dirEntry) dirEntry.isAsset = titleIsAsset;
+                        //         return readFile(dirEntry);
+                        //     }).catch(function (err) {
+                        //         console.error('Failed to read ' + transformedTitle, err);
+                        //     });
+                        // });
+                    }
+                    appstate.selectedArchive.getDirEntryByPath(title).then(function (dirEntry) {
+                        if (dirEntry) dirEntry.isAsset = titleIsAsset;
+                        return readFile(dirEntry);
+                    }).catch(function (err) {
+                        console.error('Failed to read ' + title, err);
+                        messagePort.postMessage({
+                            'action': 'giveContent',
+                            'title': title,
+                            'content': new Uint8Array
                         });
-                    };
+                    });
                 } else {
                     console.error("Invalid message received", event.data);
                 }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3975,7 +3975,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                             }
                             // Note we sometimes can get HTML "moved permanently" as a response to a request for an image
                             // particularly in Zimit archives, so we have to exclude these here
-                            if (/\bx?html\b/i.test(mimetype) && !/\.(png|gif|jpe?g|css|js|mpe?g|webp|webm|woff2?)(\?|$)/i.test(dirEntry.url)) {
+                            if (/\bx?html\b/i.test(mimetype) && !/\.(png|gif|jpe?g|css|js|mpe?g|webp|webm|woff2?|embed)(\?|$)/i.test(dirEntry.url)) {
                                 loadingArticle = title;
                                 // Intercept files of type html and apply transformations
                                 var message = {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -3975,7 +3975,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                             }
                             // Note we sometimes can get HTML "moved permanently" as a response to a request for an image
                             // particularly in Zimit archives, so we have to exclude these here
-                            if (/\bx?html\b/i.test(mimetype) && !/\.(png|gif|jpe?g|css|js|mpe?g|webp|webm|woff2?|embed)(\?|$)/i.test(dirEntry.url)) {
+                            if (/\bx?html\b/i.test(mimetype) && !/\.(png|gif|jpe?g|css|js|mpe?g|webp|webm|woff2?|embed\/.*)(\?|$)/i.test(dirEntry.url)) {
                                 loadingArticle = title;
                                 // Intercept files of type html and apply transformations
                                 var message = {

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -156,7 +156,7 @@ define([], function () {
             // Deal with regex-style urls embedded in page
             data = data.replace(/https?:\\\/\\\/[^"']+/gi, function (assetUrl) {
                 assetUrl = assetUrl.replace(/^https?:\\\/\\\//i, '\\/' + dirEntry.namespace + '\\/' + (dirEntry.namespace === 'C' ? 'A\\/' : ''));
-                assetUrl = (window.location.origin + indexRoot).replace(/\//g, '\\/') + assetUrl;
+                assetUrl = (window.location.origin + indexRoot).replace(/\\/g, '\\').replace(/([\\/])/g, '\\$1') + assetUrl;
                 return assetUrl;
             });
 

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -35,7 +35,7 @@ define([], function () {
         if (dirEntry.namespace === 'H' || dirEntry.namespace === 'C' && /^H\//.test(dirEntry.url) 
             || params.isLandingPage && /^(A\/)?index\.html(?:[?#]|$)/.test(dirEntry.url))
             dirEntry.inspect = true;
-        if (/(?:\bload\.js|\bsw\.js|analytics.*\.js|update\.googleapis|remote.loader\.js|survey\.js|yuiloader\.js|developer\.mozilla\.org\/static\/js\/main\..+\.js)(?:[?#]|$)/i.test(dirEntry.url))
+        if (/(?:\bload\.js|\bsw\.js|analytics.*\.js|update\.googleapis|survey\.js|yuiloader\.js|developer\.mozilla\.org\/static\/js\/main\..+\.js)(?:[?#]|$)/i.test(dirEntry.url))
             dirEntry.nullify = true;
         return dirEntry;
     }
@@ -62,6 +62,11 @@ define([], function () {
             } else {
                 dirEntry.zimitRedirect = null;
             }    
+        } else if (/301\s*moved\s+permanently/i.test(data)) {
+            redirect = data.match(/moved\s+permanently(?:[^<]|<(?!a\s))+<a\s[^"']+["'](?:https?:)?\/?\/?([^"']+)/i);
+            if (redirect && redirect[1]) {
+                dirEntry.zimitRedirect = cns + '/' + (cns === 'C' ? 'A/' : '') + redirect[1];
+            }
         } else {
             redirect = data.match(/window\.mainUrl\s*=\s*(['"])https?:\/\/([^\/]+)(.+?)\1/);
             if (redirect && redirect[2] && redirect[3]) {

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -118,8 +118,8 @@ define([], function () {
             // DEV: Check if this is still necessary
             data = data.replace(/<noscript>\s*(<img\b[^>]+>)\s*<\/noscript>/ig, '$1');
             data = data.replace(/<span\b[^>]+lazy-image-placeholder[^<]+<\/span>\s*/ig, '');
-            // Remove meta http-equiv refresh
-            data = data.replace(/<meta\s+http-equiv[^>]+refresh\b[^>]+>\s*/i, '');
+            // Remove meta http-equiv refresh from assets
+            if (dirEntry.isAsset) data = data.replace(/<meta\s+http-equiv[^>]+refresh\b[^>]+>\s*/i, '');
             // // Inject the helper script wombat.js
             // data = data.replace(/(<\/head>\s*)/i, '<script src="https://' + params.zimitPrefix + '/static/wombat.js"></script>\n');
 

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * transformZimit.js: Functions to enable reading of Zimit ZIM format.
  *
  * Copyright 2022 Jaifroid, Mossroy and contributors.
@@ -131,9 +131,10 @@ define([], function () {
                 assetUrl = assetUrl.replace(/^(?:https?:)?\/\//i, indexRoot + '/' + dirEntry.namespace + '/' + (dirEntry.namespace === 'C' ? 'A/' : ''));
                 // For fully relative links, we have to remove any '..' if we are in root directory
                 if (rootDirectory) assetUrl = assetUrl.replace(/^(\.\.\/?)+/, indexRoot + '/' + dirEntry.namespace + '/' + params.zimitPrefix + '/'); 
-                // We have to mark potential assets that are not easily identified as assets, due to so many html mimetypes being returned for them
-                newBlock = newBlock.replace(relAssetUrl, '@kiwixtransformed@' + assetUrl + (params.contentInjectionMode === 'serviceworker' ? '?isKiwixAsset' : ''));
-                if (/^<a\s/i.test(newBlock)) newBlock = newBlock.replace('@kiwixtransformed@', '@kiwixtrans@');
+                // Add placeholder to prevent further transformations
+                if (/^<a\s/i.test(newBlock)) newBlock = newBlock.replace(relAssetUrl, '@kiwixtrans@' + assetUrl);
+                // But for non-anchor URLs, We have to mark potential assets that are not easily identified as assets, due to so many html mimetypes being returned for them
+                else newBlock = newBlock.replace(relAssetUrl, '@kiwixtransformed@' + assetUrl + (params.contentInjectionMode === 'serviceworker' ? '?isKiwixAsset' : ''));
                 console.debug('Transform: \n' + match + '\n -> ' + newBlock);
                 return newBlock;
             });

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * transformZimit.js: Functions to enable reading of Zimit ZIM format.
  *
  * Copyright 2022 Jaifroid, Mossroy and contributors.
@@ -288,14 +288,14 @@ define([], function () {
                                 console.debug('TRANSFORMED VIDEO URL ' + pureUrl + ' --> \n' + transUrl);
                                 callback(transUrl);
                             }
-                        });
+                        }, null); // null prevents callbacks with incomplete results
                     } else {
                         callback(url);
                     }
                 } else {
                     callback(url);
                 }
-            });
+            }, null);
         } else {
             callback(url);
         }

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -67,6 +67,7 @@ define([], function () {
             if (redirect && redirect[1]) {
                 dirEntry.zimitRedirect = cns + '/' + (cns === 'C' ? 'A/' : '') + redirect[1];
             }
+            console.debug('*** Asset moved permanently! Redirecting to: ' + dirEntry.zimitRedirect + ' ***');
         } else {
             redirect = data.match(/window\.mainUrl\s*=\s*(['"])https?:\/\/([^\/]+)(.+?)\1/);
             if (redirect && redirect[2] && redirect[3]) {
@@ -118,7 +119,7 @@ define([], function () {
             data = data.replace(/<noscript>\s*(<img\b[^>]+>)\s*<\/noscript>/ig, '$1');
             data = data.replace(/<span\b[^>]+lazy-image-placeholder[^<]+<\/span>\s*/ig, '');
             // Remove meta http-equiv refresh
-            data = data.replace(/<meta\s+http-equiv[^>]+refresh\b[^>]+>\/s*/i, '');
+            data = data.replace(/<meta\s+http-equiv[^>]+refresh\b[^>]+>\s*/i, '');
             // // Inject the helper script wombat.js
             // data = data.replace(/(<\/head>\s*)/i, '<script src="https://' + params.zimitPrefix + '/static/wombat.js"></script>\n');
 

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -79,7 +79,7 @@ define([], function () {
     /**
      * Establish some Regular Expressions used by the transformReplayUrls function
      */
-    var regexpZimitHtmlLinks = /(<(?:a|img|script|link|track|meta)\b[^>]*?[\s;])(?:src\b|href|url)\s*(=\s*(["']))(?=[./]+|https?)((?:[^>](?!\3|\?|#))+[^>])([^>]*>)/ig;
+    var regexpZimitHtmlLinks = /(<(?:a|img|script|link|track|meta|iframe)\b[^>]*?[\s;])(?:src\b|href|url)\s*(=\s*(["']))(?=[./]+|https?)((?:[^>](?!\3|\?|#))+[^>])([^>]*>)/ig;
     var regexpZimitJavascriptLinks = /['"(]((?:https?:)?\/\/[^'"?#)]*)['"?#)]/ig;
     var regexpZimitCssLinks = /\burl\s*\(['"\s]*([^)'"\s]+)['"\s]*\)/ig;
     var regexpGetZimitPrefix = /link\s+rel=["']canonical["']\s+href="https?:\/\/([^/"]+)/i;
@@ -101,7 +101,7 @@ define([], function () {
          * Note that some Zimit ZIMs have mimeteypes like 'text/html;raw=true', so we can't simply match 'text/html'
          * Other ZIMs have a mimetype like 'html' (with no 'text/'), so we have to match as generically as possible
          */
-        var indexRoot = window.location.pathname.replace(/[^\/]+$/, '') + encodeURI(selectedArchive._file.name);
+        var indexRoot = window.location.origina + window.location.pathname.replace(/[^\/]+$/, '') + encodeURI(selectedArchive._file.name);
         if (/\bx?html\b/i.test(mimetype)) {
             var zimitPrefix = data.match(regexpGetZimitPrefix);
             // If the URL is the same as the URL with everything after the first / removed, then we are in the root directory
@@ -122,9 +122,9 @@ define([], function () {
                 var newBlock = match;
                 var assetUrl = relAssetUrl;
                     // DEBUG:
-                    // console.log(assetUrl);
+                    console.log('Asset URL: ' + assetUrl);
                 // Remove google analytics and other analytics files that cause stall
-                if (/google|analytics|typepad.*stats/i.test(assetUrl)) return '';
+                if (/analytics|typepad.*stats/i.test(assetUrl)) return '';
                 // For root-relative links, we need to add the zimitPrefix
                 assetUrl = assetUrl.replace(/^\/(?!\/)/, indexRoot + '/' + dirEntry.namespace + '/' + params.zimitPrefix + '/');
                 // For Zimit assets that begin with https: or // the zimitPrefix is derived from the URL
@@ -134,7 +134,7 @@ define([], function () {
                 // Deal with <meta http-equiv refresh...> directives
                 // if (/<meta\s+http-equiv[^>]+refresh\b/i.test(newBlock)) dirEntry.zimitRedirect = assetUrl.replace(/^\//, '');
                 newBlock = newBlock.replace(relAssetUrl, '@kiwixtransformed@' + assetUrl);
-                // console.debug('Transform: \n' + match + '\n -> ' + newBlock);
+                console.debug('Transform: \n' + match + '\n -> ' + newBlock);
                 return newBlock;
             });
 
@@ -209,7 +209,7 @@ define([], function () {
                 // Relative assets
                 newBlock = assetUrl === url ? newBlock :
                     newBlock.replace(url, '@kiwixtransformed@' + '/' + selectedArchive._file.name + '/' + assetUrl);
-                // console.debug('Transform: \n' + match + '\n -> ' + newBlock);
+                console.debug('Transform: \n' + match + '\n -> ' + newBlock);
                 return newBlock;
             });
         } // End of css transformations
@@ -226,13 +226,13 @@ define([], function () {
                 assetUrl = assetUrl.replace(/^\/\//, dirEntry.namespace + '/' + (dirEntry.namespace === 'C' ? 'A/' : ''));
                 assetUrl = assetUrl.replace(/^https?:\/\//i, dirEntry.namespace + '/' + (dirEntry.namespace === 'C' ? 'A/' : '')); 
                 // Remove analytics
-                assetUrl = /google|analytics|typepad.*stats/i.test(assetUrl) ? '' : assetUrl; 
+                assetUrl = /analytics|typepad.*stats/i.test(assetUrl) ? '' : assetUrl; 
                 // Relative assets
                 newBlock = newBlock.replace(url, '/' + selectedArchive._file.name + '/' + assetUrl);
-                // console.debug('Transform: \n' + match + '\n -> ' + newBlock);
+                console.debug('Transform: \n' + match + '\n -> ' + newBlock);
                 return newBlock;
             });
-            data = data.replace(/(['"])(?:\/?)((?:static|api)\/)/ig, '$1' + window.location.origin + indexRoot + '/' + dirEntry.namespace + '/' + params.zimitPrefix + '/$2');
+            data = data.replace(/(['"])(?:\/?)((?:static|api)\/)/ig, '$1' + indexRoot + '/' + dirEntry.namespace + '/' + params.zimitPrefix + '/$2');
         } // End of JavaScript transformations
 
         // Add a base href

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -156,7 +156,7 @@ define([], function () {
             // Deal with regex-style urls embedded in page
             data = data.replace(/https?:\\\/\\\/[^"']+/gi, function (assetUrl) {
                 assetUrl = assetUrl.replace(/^https?:\\\/\\\//i, '\\/' + dirEntry.namespace + '\\/' + (dirEntry.namespace === 'C' ? 'A\\/' : ''));
-                assetUrl = (window.location.origin + indexRoot).replace(/\\/g, '\\\\').replace(/([\\/])/g, '\\$1') + assetUrl;
+                assetUrl = (window.location.origin + indexRoot).replace(/\\/g, '\\\\').replace(/\//g, '\\/') + assetUrl;
                 return assetUrl;
             });
 

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -156,7 +156,7 @@ define([], function () {
             // Deal with regex-style urls embedded in page
             data = data.replace(/https?:\\\/\\\/[^"']+/gi, function (assetUrl) {
                 assetUrl = assetUrl.replace(/^https?:\\\/\\\//i, '\\/' + dirEntry.namespace + '\\/' + (dirEntry.namespace === 'C' ? 'A\\/' : ''));
-                assetUrl = (window.location.origin + indexRoot).replace(/\\/g, '\\').replace(/([\\/])/g, '\\$1') + assetUrl;
+                assetUrl = (window.location.origin + indexRoot).replace(/\\/g, '\\\\').replace(/([\\/])/g, '\\$1') + assetUrl;
                 return assetUrl;
             });
 

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * transformZimit.js: Functions to enable reading of Zimit ZIM format.
  *
  * Copyright 2022 Jaifroid, Mossroy and contributors.
@@ -244,9 +244,22 @@ define([], function () {
         return data;
     }
 
+    /**
+     * Transform fuzzy URL
+     * Rules adapted from https://github.com/webrecorder/wabac.js/blob/main/src/fuzzymatcher.js
+     * @param {String} url The URL to transform through fuzzy matching 
+     */
+    function transformFuzzyUrl(url) {
+        if (/videoId/i.test(url)) {
+            url = url.replace(/\/(?:www\.)?youtube(?:-nocookie)?\.com\/(youtubei\/v1\/[^?]+\?).*(videoId[^&]+).*/i, '/youtube.fuzzy.replayweb.page/$1$2');
+        }
+        return url;
+    }
+
     return {
         filterReplayFiles: filterReplayFiles,
         getZimitRedirect: getZimitRedirect,
-        transformReplayUrls: transformReplayUrls
+        transformReplayUrls: transformReplayUrls,
+        transformFuzzyUrl: transformFuzzyUrl
     };
 });

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -249,7 +249,7 @@ define([], function () {
         }
 
         // Transform video URLs
-        if (/\.youtu(?:be(?:-nocookie)?\.com|\.be)/i.test(data)) {
+        if (/youtu(?:be(?:-nocookie)?\.com|\.be)\//i.test(data)) {
             var cns = appstate.selectedArchive.getContentNamespace();
             var rgxTrimUrl = new RegExp('@kiwixtrans(?:[^/]|\\/(?!' + cns + '\\/))+\\/');
             var youTubeVideoLinks = data.match(/@kiwixtrans(?:[^"')>@]|@(?!kiwixtrans))*youtu(?:be(?:-nocookie)?\.com|\.be)[^"')>]*/ig);

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -99,9 +99,10 @@ define([], function () {
      * @param {String} data The deocmpressed and extracted textual data that the dirEntry points to
      * @param {String} mimetype The reported mimetype of the data (this is also in the dirEntry)
      * @param {Object} selectedArchive The archive object (needed only for the standardized filename used as a prefix)
+     * @param {Function} callback The function to call with the transformed data
      * @returns {String} The data string with any URLs it contains transformed into ZIM URLs 
      */
-    function transformReplayUrls(dirEntry, data, mimetype, selectedArchive) {
+    function transformReplayUrls(dirEntry, data, mimetype, selectedArchive, callback) {
         /**
          * Transform URL links in HTML files
          * Note that some Zimit ZIMs have mimeteypes like 'text/html;raw=true', so we can't simply match 'text/html'
@@ -256,7 +257,6 @@ define([], function () {
      * Rules adapted from https://github.com/webrecorder/wabac.js/blob/main/src/fuzzymatcher.js
      * @param {String} url The URL to transform through fuzzy matching
      * @param {Function} callback The function to call with the transformed url
-     * @returns {Promise<String>} A Promise for the transformed URL
      */
     function transformVideoUrl(url, callback) {
         if (/\.youtu(?:be(?:-nocookie)?\.com|\.be)/i.test(url)) {

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -98,16 +98,15 @@ define([], function () {
      * @param {dirEntry} dirEntry The directory entry that points to the extracted data
      * @param {String} data The deocmpressed and extracted textual data that the dirEntry points to
      * @param {String} mimetype The reported mimetype of the data (this is also in the dirEntry)
-     * @param {Object} selectedArchive The archive object (needed only for the standardized filename used as a prefix)
      * @param {Function} callback The function to call with the transformed data string
      */
-    function transformReplayUrls(dirEntry, data, mimetype, selectedArchive, callback) {
+    function transformReplayUrls(dirEntry, data, mimetype, callback) {
         /**
          * Transform URL links in HTML files
          * Note that some Zimit ZIMs have mimeteypes like 'text/html;raw=true', so we can't simply match 'text/html'
          * Other ZIMs have a mimetype like 'html' (with no 'text/'), so we have to match as generically as possible
          */
-        var indexRoot = window.location.pathname.replace(/[^\/]+$/, '') + encodeURI(selectedArchive._file.name);
+        var indexRoot = window.location.pathname.replace(/[^\/]+$/, '') + encodeURI(appstate.selectedArchive._file.name);
         if (/\bx?html\b/i.test(mimetype)) {
             var zimitPrefix = data.match(regexpGetZimitPrefix);
             // If the URL is the same as the URL with everything after the first / removed, then we are in the root directory
@@ -251,14 +250,14 @@ define([], function () {
 
         // Transform video URLs
         if (/\.youtu(?:be(?:-nocookie)?\.com|\.be)/i.test(data)) {
-            var cns = selectedArchive.getContentNamespace();
+            var cns = appstate.selectedArchive.getContentNamespace();
             var rgxTrimUrl = new RegExp('@kiwixtrans(?:[^/]|\\/(?!' + cns + '\\/))+\\/');
             var youTubeVideoLinks = data.match(/@kiwixtrans(?:[^"')>@]|@(?!kiwixtrans))*youtu(?:be(?:-nocookie)?\.com|\.be)[^"')>]*/ig);
             if (youTubeVideoLinks && youTubeVideoLinks.length) {
                 var i = 0;
                 youTubeVideoLinks.forEach(function (link) {
                     var pureUrl = link.replace(rgxTrimUrl, '');
-                    transformVideoUrl(pureUrl, selectedArchive, function (transUrl) {
+                    transformVideoUrl(pureUrl, appstate.selectedArchive, function (transUrl) {
                         i++;
                         console.debug('i=' + i);
                         data = data.replace(link, link.replace(pureUrl, transUrl));
@@ -278,10 +277,9 @@ define([], function () {
      * Transform video URL through fuzzy matching
      * Rules adapted from https://github.com/webrecorder/wabac.js/blob/main/src/fuzzymatcher.js
      * @param {String} url The URL to transform through fuzzy matching
-     * @param {Object} selectedArchive The selected archive 
      * @param {Function} callback The function to call with the transformed url
      */
-    function transformVideoUrl(url, selectedArchive, callback) {
+    function transformVideoUrl(url, callback) {
         if (/youtu(?:be(?:-nocookie)?\.com|\.be)/i.test(url)) {
             // See https://webapps.stackexchange.com/questions/54443/format-for-id-of-youtube-video for explanation of format
             var videoId = url.match(/(?:videoid=|watch\?v=|embed\/|\/)([a-zA-Z0-9_-]{10}[048AEIMQUYcgkosw](?:&|\?|\s*$))/i);
@@ -290,7 +288,7 @@ define([], function () {
                 callback(url);
                 return
             };
-            var cns = selectedArchive.getContentNamespace();
+            var cns = appstate.selectedArchive.getContentNamespace();
             var prefix = (cns === 'C' ? cns + '/' : '') + 'H/www.youtube.com/ptracking';
             // Set up regular expression search of URL index (aka fuzzy search)
             var search = {
@@ -298,7 +296,7 @@ define([], function () {
                 searchUrlIndex: true,
                 size: 1
             }
-            selectedArchive.findDirEntriesWithPrefixCaseSensitive(prefix, search, function (dirEntry) {
+            appstate.selectedArchive.findDirEntriesWithPrefixCaseSensitive(prefix, search, function (dirEntry) {
                 if (dirEntry && dirEntry[0] && dirEntry[0].url) {
                     dirEntry = dirEntry[0];
                     console.log('PASS 1: FOUND DIRENTRY: ', dirEntry);
@@ -313,7 +311,7 @@ define([], function () {
                             searchUrlIndex: true,
                             size: 1
                         }
-                        selectedArchive.findDirEntriesWithPrefixCaseSensitive(prefix, search, function (dirEntry) {
+                        appstate.selectedArchive.findDirEntriesWithPrefixCaseSensitive(prefix, search, function (dirEntry) {
                             if (dirEntry && dirEntry[0] && dirEntry[0].url) {
                                 dirEntry = dirEntry[0];
                                 console.log('PASS 2: FOUND DIRENTRY: ', dirEntry);

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -843,7 +843,7 @@ define(rqDef, function(util) {
      * @param {Event} event The click event (on an anchor) to handle
      * @param {Element} clickedAnchor The DOM anchor that has been clicked (optional, defaults to event.target)
      */
-    function warnAndOpenExternalLinkInNewTab(event, clickedAnchor) {
+    function warnAndOpenExternalLinkInNewTab(event, clickedAnchor, message) {
         if (event) {
             event.preventDefault();
             event.stopPropagation();
@@ -851,7 +851,8 @@ define(rqDef, function(util) {
         if (!clickedAnchor) clickedAnchor = event.target;
         var target = clickedAnchor.target;
         var href = clickedAnchor.protocol ? clickedAnchor.href : 'http://' + clickedAnchor.href;
-        var message = '<p>Click the link to open this ' + (/https:\/\/www.openstreetmap.*?mlat/.test(href) ? 'map' : 'external page');
+        clickedAnchor.type = clickedAnchor.type || (/https:\/\/www.openstreetmap.*?mlat/.test(href) ? 'map' : 'link');
+        var message = message || '<p>Click the link to open this external ' + clickedAnchor.type;
         if (!target || target === '_blank') {
             target = '_blank';
             message += ' (in a new tab)';
@@ -864,7 +865,7 @@ define(rqDef, function(util) {
             }
         };
         if (params.openExternalLinksInNewTabs) {
-            systemAlert(message, 'Opening external link', false, null, null, 'Close');
+            systemAlert(message, 'Opening external ' + clickedAnchor.type, false, null, null, 'Close');
             // Close dialog box if user clicks the link
             document.getElementById('kiwixExternalLink').addEventListener('click', function (e) {
                 if (/https:\/\/www.openstreetmap.*?mlat/.test(href)) {

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -350,11 +350,11 @@ define(rqDef, function(util) {
             alertHTML =
             '<div id="activeContent" class="alert alert-warning alert-dismissible fade in" style="margin-bottom: 0;">' +
                 '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>' +
-                '<strong>' + (params.contentInjectionMode === 'jquery' ? 'Limited Zimit' : 'Experimental') + ' support:</strong> ' + 
-                (params.contentInjectionMode === 'jquery' ? 'Please <a id="swModeLink" href="#contentInjectionModeDiv" ' + 
+                // '<strong>' + (params.contentInjectionMode === 'jquery' ? 'Limited Zimit' : 'Experimental') + ' support:</strong> ' + 
+                (params.contentInjectionMode === 'jquery' ? '<b>Limited support!</b> Please <a id="swModeLink" href="#contentInjectionModeDiv" ' + 
                 'class="alert-link">switch to Service Worker mode</a> if your platform supports it. ' : 
-                'Support for <b>Zimit</b> ZIMs is preliminary. Some content (e.g. audio/video) may fail. ') + 
-                '<br />Search for your content above. Start your search with <b>.*</b> to match part of a title, ' +
+                'Support for <b>Zimit</b> ZIMs is experimental. Some content (e.g. audio/video) may fail. ') + 
+                'You can search for content above. <br />Start your search with <b>.*</b> to match part of a title, ' +
                 'or type a <b><i>space</i></b> to use the Archive Index, or <b><i>space + / </i></b> for URL Index.&nbsp;' +
                 '[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]' +
             '</div>';

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -458,6 +458,13 @@ define(rqDef, function(util) {
         alertMessage.innerHTML = '<strong>Download</strong> If the download does not start, please tap the following link: ';
         // We have to add the anchor to a UI element for Firefox to be able to click it programmatically: see https://stackoverflow.com/a/27280611/9727685
         alertMessage.appendChild(a);
+        // For IE11 we need to force use of the saveBlob method with the onclick event 
+        if (window.navigator && window.navigator.msSaveBlob) {
+            a.addEventListener('click', function (e) {
+                window.navigator.msSaveBlob(blob, filename);
+                e.preventDefault();
+            });
+        } 
         try {
             a.click();
             // Following line should run only if there was no error, leaving the alert showing in case of error
@@ -474,22 +481,13 @@ define(rqDef, function(util) {
             if (autoDismiss) $('#downloadAlert').alert('close');
         }
         catch (err) {
-            // If the click fails, user may be able to download by manually clicking the link
-            // But for IE11 we need to force use of the saveBlob method with the onclick event 
-            if (window.navigator && window.navigator.msSaveBlob) {
-                a.addEventListener('click', function (e) {
-                    window.navigator.msSaveBlob(blob, filename);
-                    e.preventDefault();
-                });
+            // And try to launch through UWP download
+            if (Windows && Windows.Storage) {
+                downloadBlobUWP(blob, filename, alertMessage);
+                if (autoDismiss) $('#downloadAlert').alert('close');
             } else {
-                // And try to launch through UWP download
-                if (Windows && Windows.Storage) {
-                    downloadBlobUWP(blob, filename, alertMessage);
-                    if (autoDismiss) $('#downloadAlert').alert('close');
-                } else {
-                    // Last gasp attempt to open automatically
-                    window.open(a.href);
-                }
+                // Last gasp attempt to open automatically
+                window.open(a.href);
             }
         }
     }

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -466,12 +466,9 @@ define(['zimfile', 'zimDirEntry', 'transformZimit', 'util', 'utf8'],
                 // DEV: Note that we cannot terminate regex below with $ because there is a (rogue?) mimetype
                 // of 'text/html;raw=true'
                 if (params.zimType === 'zimit' && /\/(?:html|css|javascript)\b/i.test(mimetype)) {
-                    transformZimit.transformReplayUrls(dirEntry, data, mimetype, function (transData) {
-                        callback(dirEntry, transData);
-                    });
-                } else {
-                    callback(dirEntry, data);
-                }
+                    data = transformZimit.transformReplayUrls(dirEntry, data, mimetype);
+                } 
+                callback(dirEntry, data);
             }
         });
     };
@@ -501,12 +498,9 @@ define(['zimfile', 'zimDirEntry', 'transformZimit', 'util', 'utf8'],
                 // DEV: Note that we cannot terminate regex below with $ because there is a (rogue?) mimetype
                 // of 'text/html;raw=true'
                 if (params.zimType === 'zimit' && /\/(?:html|css|javascript)\b/i.test(mimetype)) {
-                    transformZimit.transformReplayUrls(dirEntry, utf8.parse(data), mimetype, function (transData) {
-                        callback(dirEntry, transData);
-                    });
-                } else {
-                    callback(dirEntry, data);
+                    data = transformZimit.transformReplayUrls(dirEntry, utf8.parse(data), mimetype);
                 }
+                callback(dirEntry, data);
             }
         });
     };

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -466,9 +466,12 @@ define(['zimfile', 'zimDirEntry', 'transformZimit', 'util', 'utf8'],
                 // DEV: Note that we cannot terminate regex below with $ because there is a (rogue?) mimetype
                 // of 'text/html;raw=true'
                 if (params.zimType === 'zimit' && /\/(?:html|css|javascript)\b/i.test(mimetype)) {
-                    data = transformZimit.transformReplayUrls(dirEntry, data, mimetype, appstate.selectedArchive);
+                    transformZimit.transformReplayUrls(dirEntry, data, mimetype, appstate.selectedArchive, function (transData) {
+                        callback(dirEntry, transData);
+                    });
+                } else {
+                    callback(dirEntry, data);
                 }
-                callback(dirEntry, data);
             }
         });
     };
@@ -498,10 +501,13 @@ define(['zimfile', 'zimDirEntry', 'transformZimit', 'util', 'utf8'],
                 // DEV: Note that we cannot terminate regex below with $ because there is a (rogue?) mimetype
                 // of 'text/html;raw=true'
                 if (params.zimType === 'zimit' && /\/(?:html|css|javascript)\b/i.test(mimetype)) {
-                    data = transformZimit.transformReplayUrls(dirEntry, utf8.parse(data), mimetype, that);
+                    transformZimit.transformReplayUrls(dirEntry, utf8.parse(data), mimetype, appstate.selectedArchive, function (transData) {
+                        callback(dirEntry, transData);
+                    });
+                } else {
+                    callback(dirEntry, data);
                 }
             }
-            callback(dirEntry, data);
         });
     };
     

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -466,7 +466,7 @@ define(['zimfile', 'zimDirEntry', 'transformZimit', 'util', 'utf8'],
                 // DEV: Note that we cannot terminate regex below with $ because there is a (rogue?) mimetype
                 // of 'text/html;raw=true'
                 if (params.zimType === 'zimit' && /\/(?:html|css|javascript)\b/i.test(mimetype)) {
-                    transformZimit.transformReplayUrls(dirEntry, data, mimetype, appstate.selectedArchive, function (transData) {
+                    transformZimit.transformReplayUrls(dirEntry, data, mimetype, function (transData) {
                         callback(dirEntry, transData);
                     });
                 } else {
@@ -501,7 +501,7 @@ define(['zimfile', 'zimDirEntry', 'transformZimit', 'util', 'utf8'],
                 // DEV: Note that we cannot terminate regex below with $ because there is a (rogue?) mimetype
                 // of 'text/html;raw=true'
                 if (params.zimType === 'zimit' && /\/(?:html|css|javascript)\b/i.test(mimetype)) {
-                    transformZimit.transformReplayUrls(dirEntry, utf8.parse(data), mimetype, appstate.selectedArchive, function (transData) {
+                    transformZimit.transformReplayUrls(dirEntry, utf8.parse(data), mimetype, function (transData) {
                         callback(dirEntry, transData);
                     });
                 } else {


### PR DESCRIPTION
When completed, this PR should fix #292.

Progress:

- [x] Enable iframe support (embedded videos are contained in iframes on an article page)
- [x] Finesse URL substitution in the video js files loaded as part of iframe
- [x] Ability to show image placeholders in embedded video playback widget
- [x] Handle POST Fetch events in Service Worker
- [x] ~~Apply fuzzy matching URL substution for video playback~~ (this doesn't provide any new information at least for YouTube videos)
- [x] Transparently get link to video BLOB from videoId (at least for YouTube)
- [x] Make video embeds point to video BLOB (mp4)
- [ ] ~~Enable more chrome of the YouTube embeds (currently they don't show the video playback icon, for example)~~ (this will have to be left for another issue/PR)
- [x] Force YouTube links to point to vidoe BLOB if it exists
- [x] Refactor so that video is loaded after first paint - should also prevent race condition causing page display failures