### PR TITLE
Provide default auto setting for display of hidden block elements

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -836,10 +836,10 @@
                                             <b>Remove max page width restriction</b>: [ <b><span id="pageMaxWidthState"></span></b> ] (useful for recent Wikipedia archives)
                                         </label>
                                         <div id="displayHiddenBlockElementsDiv">
-                                            <label class="checkbox" title="Show navboxes, tables and other elements that tend to be hidden in Wikipedia mobile style. Not needed if you select Desktop display style.">
+                                            <label class="checkbox" title="Show navboxes, tables and other elements that tend to be hidden in Wikipedia mobile style. Not needed if you select Desktop display style. 'Auto' applies setting only to Wikimedia archives in mobile style.">
                                                 <input name="displayHiddenBlockElements" id="displayHiddenBlockElementsCheck" type="checkbox" value="false">
                                                 <span class="checkmark"></span>
-                                                <b>Display hidden block elements</b> (<i>for Wikipedia ZIMs, experimental</i>: shows elements that are hidden in mobile style)
+                                                <b>Display hidden block elements</b>: [ <b><span id="displayHiddenElementsState"></span></b> ] (<i>for Wikimedia ZIMs</i>: shows elements that are hidden in mobile style)
                                             </label>
                                         </div>
                                     </div>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1800,12 +1800,15 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             if (this.readOnly) this.checked = this.readOnly = false;
             else if (!this.checked) this.readOnly = this.indeterminate = true;
             params.removePageMaxWidth = this.indeterminate ? "auto" : this.checked;
-            document.getElementById('pageMaxWidthState').innerHTML = (params.removePageMaxWidth == "auto" ? "auto" : params.removePageMaxWidth ? "always" : "never");
+            document.getElementById('pageMaxWidthState').textContent = (params.removePageMaxWidth == "auto" ? "auto" : params.removePageMaxWidth ? "always" : "never");
             settingsStore.setItem('removePageMaxWidth', params.removePageMaxWidth, Infinity);
             removePageMaxWidth();
         });
         document.getElementById('displayHiddenBlockElementsCheck').addEventListener('click', function () {
-            params.displayHiddenBlockElements = this.checked;
+            if (this.readOnly) this.checked = this.readOnly = false;
+            else if (!this.checked) this.readOnly = this.indeterminate = true;
+            params.displayHiddenBlockElements = this.indeterminate ? "auto" : this.checked;
+            document.getElementById('displayHiddenElementsState').textContent = (params.displayHiddenBlockElements == "auto" ? "auto" : params.displayHiddenBlockElements ? "always" : "never");
             settingsStore.setItem('displayHiddenBlockElements', params.displayHiddenBlockElements, Infinity);
             if (params.contentInjectionMode === 'serviceworker') {
                 var message = '';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5276,15 +5276,29 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             Array.prototype.slice.call(doc.querySelectorAll('table, div')).forEach(function (element) {
                 if (win.getComputedStyle(element).display === 'none') {
                     element.style.setProperty('display', 'block', 'important');
-                    if (!params.noHiddenElementsWarning && params.cssSource !== 'desktop') {
+                    if (!params.noHiddenElementsWarning) {
                         params.noHiddenElementsWarning = true;
-                        uiUtil.systemAlert('<p>There is a new <b>auto</b> setting in Configuration to display hidden tables (series info, navigaiton boxes) ' +
-                        'by default in Wikimedia ZIMs. If you do not want to see these elements, set the option to <b>never</b>.</p>' +
-                        '<p>Please note that these elements are always displayed in Desktop style by design, so consider switching the display style ' +
-                        '(see Configuration) for better layout of such elements.</p>' +
-                        '<p><i>This message will not be displayed again, unless you reset the app.</i></p>', 'One-time message!').then(function () {
-                            settingsStore.setItem('noHiddenElementsWarning', true, Infinity);
-                        });
+                        var message;
+                        if (!appstate.wikimediaZimLoaded) {
+                            message = '<p>The way the <i>Display hidden block elements setting</i> works has changed! Because it is currently set ' +
+                            'to <b>always</b>, it will now apply to <i>any</i> ZIM type. This can have unexpected effects in non-Wikipedia ZIMs.</p>' +
+                            '<p>We strongly recommend that you change this setting to <b>auto</b> in Configuration. The new auto setting allows the ' +
+                            'app to decide when to apply the setting. If you never want to see hidden elements, even in Wikimedia ZIMs, change the ' +
+                            'setting to <b>never</b>.</p>';
+                        } else if (params.displayHiddenBlockElements === 'auto') {  
+                            message =  '<p>There is a new <b>auto</b> setting in Configuration to display hidden tables (series info, navigaiton boxes) ' +
+                            'by default in Wikimedia ZIMs. This is now on by default. If you do not want to see these elements, change the setting to <b>never</b>.</p>';
+                            if (params.cssSource !== 'desktop') {
+                                message += '<p>Please note that these elements are always displayed in Desktop style by design' + (params.cssSource !== 'desktop' ? 
+                                ', so consider switching the display style (see Configuration) if you are not on a larger-screen device' : '') + '.</p>';
+                            }
+                        }
+                        if (message) {
+                            message += '<p><i>This message will not be displayed again, unless you reset the app.</i></p>';
+                            uiUtil.systemAlert(message, 'One-time message!').then(function () {
+                                settingsStore.setItem('noHiddenElementsWarning', true, Infinity);
+                            });
+                        }
                     }
                 }
             });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1216,15 +1216,15 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                 );
             }
             if (this.value === 'serviceworker') {
-                var wikimediaZimLoaded = appstate.selectedArchive && /wikipedia|wikivoyage|mdwiki|wiktionary/i.test(appstate.selectedArchive._file.name);
+                appstate.wikimediaZimLoaded = appstate.selectedArchive && /wikipedia|wikivoyage|mdwiki|wiktionary/i.test(appstate.selectedArchive._file.name);
                 if (params.displayHiddenBlockElements || params.manipulateImages || params.allowHTMLExtraction) {
-                    if (!wikimediaZimLoaded) uiUtil.systemAlert(
+                    if (!appstate.wikimediaZimLoaded) uiUtil.systemAlert(
                         'Please note that we are disabling Image manipulation, Breakout link and/or Display hidden block elements, as these options can interfere with ZIMs that have active content. You may turn them back on, but be aware that they are only recommended for use with Wikimedia ZIMs.'
                     );
                 }
-                if (!wikimediaZimLoaded) {
+                if (!appstate.wikimediaZimLoaded) {
                     if (params.manipulateImages) document.getElementById('manipulateImagesCheck').click();
-                    if (params.displayHiddenBlockElements) document.getElementById('displayHiddenBlockElementsCheck').click();
+                    // if (params.displayHiddenBlockElements) document.getElementById('displayHiddenBlockElementsCheck').click();
                     if (params.allowHTMLExtraction) document.getElementById('allowHTMLExtractionCheck').click();
                 }
             }
@@ -2850,10 +2850,10 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                     // (this only affects jQuery mode)
                     appstate.target = 'iframe';
                     if (params.contentInjectionMode === 'serviceworker') {
-                        var wikimediaZimLoaded = appstate.selectedArchive && /wikipedia|wikivoyage|mdwiki|wiktionary/i.test(appstate.selectedArchive._file.name);
-                        if (!wikimediaZimLoaded) {
+                        appstate.wikimediaZimLoaded = appstate.selectedArchive && /wikipedia|wikivoyage|mdwiki|wiktionary/i.test(appstate.selectedArchive._file.name);
+                        if (!appstate.wikimediaZimLoaded) {
                             if (params.manipulateImages) document.getElementById('manipulateImagesCheck').click();
-                            if (params.displayHiddenBlockElements) document.getElementById('displayHiddenBlockElementsCheck').click();
+                            if (settingsStore.getItem('displayHiddenBlockeElements') === 'auto') params.displayHiddenBlockElements = false;
                             if (params.allowHTMLExtraction) document.getElementById('allowHTMLExtractionCheck').click();
                             // Set defaults that allow for greatest compabitibility with Zimit ZIM types
                             if (params.zimType === 'zimit') {
@@ -2869,6 +2869,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                         } else {
                             params.noWarning = true;
                             if (!params.manipulateImages) document.getElementById('manipulateImagesCheck').click();
+                            if (settingsStore.getItem('displayHiddenBlockeElements') === 'auto') params.displayHiddenBlockElements = 'auto';
                             params.noWarning = false;
                             params.cssTheme = settingsStore.getItem('cssTheme') || 'light';
                             if (params.cssTheme === 'auto') {
@@ -3230,8 +3231,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                 // (this only affects jQuery mode)
                 appstate.target = 'iframe';
                 if (params.contentInjectionMode === 'serviceworker') {
-                    var wikimediaZimLoaded = appstate.selectedArchive && /wikipedia|wikivoyage|mdwiki|wiktionary/i.test(appstate.selectedArchive._file.name);
-                    if (!wikimediaZimLoaded) {
+                    appstate.wikimediaZimLoaded = appstate.selectedArchive && /wikipedia|wikivoyage|mdwiki|wiktionary/i.test(appstate.selectedArchive._file.name);
+                    if (!appstate.wikimediaZimLoaded) {
                         if (params.manipulateImages) document.getElementById('manipulateImagesCheck').click();
                         if (settingsStore.getItem('displayHiddenBlockeElements') === 'auto') params.displayHiddenBlockElements = false;
                         if (params.allowHTMLExtraction) document.getElementById('allowHTMLExtractionCheck').click();
@@ -4966,7 +4967,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
 
                 // Display any hidden block elements, with a timeout, so as not to interfere with image loading
                 if (params.displayHiddenBlockElements) setTimeout(function () {
-                    if (params.zimType === 'open' || params.displayHiddenBlockElements === true) {
+                    if (appstate.wikimediaZimLoaded || params.displayHiddenBlockElements === true) {
                         displayHiddenBlockElements(articleWindow, articleDocument);
                     }
                 }, 1200);

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -77,7 +77,7 @@ params['relativeFontSize'] = ~~(getSetting('relativeFontSize') || 100); //Sets t
 params['relativeUIFontSize'] = ~~(getSetting('relativeUIFontSize') || 100); //Sets the initial font size for UI (as a percentage) - user can adjust using slider in Config
 params['cssSource'] = getSetting('cssSource') || "auto"; //Set default to "auto", "desktop" or "mobile"
 params['removePageMaxWidth'] = getSetting('removePageMaxWidth') != null ? getSetting('removePageMaxWidth') : "auto"; //Set default for removing max-width restriction on Wikimedia pages ("auto" = removed in desktop, not in mobile; true = always remove; false = never remove)
-params['displayHiddenBlockElements'] = getSetting('displayHiddenBlockElements') !== null ? getSetting('displayHiddenBlockElements') : false; //Set default for displaying hidden block elements
+params['displayHiddenBlockElements'] = getSetting('displayHiddenBlockElements') !== null ? getSetting('displayHiddenBlockElements') : "auto"; //Set default for displaying hidden block elements ("auto" = displayed in Wikimedia archives in mobile style)
 params['openAllSections'] = getSetting('openAllSections') != null ? getSetting('openAllSections') : true; //Set default for opening all sections in ZIMs that have collapsible sections and headings ("auto" = let CSS decide according to screen width; true = always open until clicked by user; false = always closed until clicked by user)
 params['cssCache'] = getSetting('cssCache') != null ? getSetting('cssCache') : true; //Set default to true to use cached CSS, false to use Zim only
 params['cssTheme'] = getSetting('cssTheme') || 'light'; //Set default to 'auto', 'light', 'dark' or 'invert' to use respective themes for articles
@@ -214,10 +214,13 @@ document.getElementById('navButtonsPosCheck').checked = params.navButtonsPos ===
 document.getElementById('imageDisplayModeCheck').checked = params.imageDisplay;
 document.getElementById('manipulateImagesCheck').checked = params.manipulateImages;
 document.getElementById('removePageMaxWidthCheck').checked = params.removePageMaxWidth === true; // Will be false if false or auto
-document.getElementById('removePageMaxWidthCheck').indeterminate = params.removePageMaxWidth == "auto";
-document.getElementById('removePageMaxWidthCheck').readOnly = params.removePageMaxWidth == "auto";
-document.getElementById('pageMaxWidthState').innerHTML = (params.removePageMaxWidth == "auto" ? "auto" : params.removePageMaxWidth ? "always" : "never");
-document.getElementById('displayHiddenBlockElementsCheck').checked = params.displayHiddenBlockElements;
+document.getElementById('removePageMaxWidthCheck').indeterminate = params.removePageMaxWidth === 'auto';
+document.getElementById('removePageMaxWidthCheck').readOnly = params.removePageMaxWidth === 'auto';
+document.getElementById('pageMaxWidthState').textContent = (params.removePageMaxWidth === "auto" ? "auto" : params.removePageMaxWidth ? "always" : "never");
+document.getElementById('displayHiddenBlockElementsCheck').checked = params.displayHiddenBlockElements === true;
+document.getElementById('displayHiddenBlockElementsCheck').indeterminate = params.displayHiddenBlockElements === 'auto';
+document.getElementById('displayHiddenBlockElementsCheck').readOnly = params.displayHiddenBlockElements === 'auto';
+document.getElementById('displayHiddenElementsState').textContent = (params.displayHiddenBlockElements === "auto" ? "auto" : params.displayHiddenBlockElements ? "always" : "never");
 document.getElementById('openAllSectionsCheck').checked = params.openAllSections;
 document.getElementById('linkToWikimediaImageFileCheck').checked = params.linkToWikimediaImageFile;
 document.getElementById('useOSMCheck').checked = /openstreetmap/.test(params.mapsURI);

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -129,6 +129,7 @@ params.localUWPSettings = /UWP/.test(params.appType) ? Windows.Storage.Applicati
 appstate['target'] = 'iframe'; // The target for article loads (this should always be 'iframe' initially, and will only be changed as a result of user action)
 params['mapsURI'] = getSetting('mapsURI') || (/UWP|Windows/.test(params.appType) ? 'bingmaps:' : 'https://www.openstreetmap.org/'); // Protocol with colon ('bingmaps:') or URL with final slash ('https://www.openstreetmap.org/')
 params['debugLibzimASM'] = getSetting('debugLibzimASM'); // 'wasm|asm' Forces use of wasm or asm for libzim decoder. You can also set this as an override URL querystring e.g. ?debugLibzimASM=wasm;
+params['noHiddenElementsWarning'] = getSetting('noHiddenElementsWarning') !== null ? getSetting('noHiddenElementsWarning') : false; // A one-time warning about Hidden elements display
 
 // Apply any override parameters in querystring (done as a self-calling function to avoid creating global variables)
 (function overrideParams() {


### PR DESCRIPTION
This provides much more intelligent switching between display of navboxes, etc., with Wikimedia ZIMs and normal display with other ZIM types.