### PR TITLE
Rework file selection UI for legacy file picker

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -676,7 +676,7 @@
                     <div id="divInstall2" style="display:none; float:right;">
                         <button id="btnInstall2" class="btn btn-xs btn-primary btn-inline">Install PWA</button>
                     </div>
-                    <div class="row" style="padding-bottom:1em;">
+                    <div class="row">
                         <h2 style="margin-top:0;">Configuration</h2>
                         <div id="alertBoxPersistent"></div>
                         <p style="margin: 1em auto 1em;">
@@ -735,20 +735,15 @@
                                         <p>For multiple or split archives</p>
                                     </div>
                                 </div>
-                                <div id="instructions" class="row" style="display:none;">
-                                    <p>
-                                        Please choose the location of your ZIM archive or drag-and-drop the file(s) here.<br />
-                                        For a split archive (.zimaa, .zimab, etc.) you must select <b>all</b> the split parts.
-                                    </p>
-                                </div>
-                                <div class="row">
-                                    <input style="display:none;" type="file" class="btn btn-primary btn-inline" value="Select folder with ZIM files" id="archiveFilesLegacy" multiple 
+                                <div class="row" style="padding-bottom: 0.5em;">
+                                    <input type="file" class="btn btn-primary btn-inline" value="Select folder with ZIM files" id="archiveFilesLegacy" multiple 
                                         accept="application/x-zim,.zim,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz, .zimba, .zimbb, .zimbc, .zimbd, .zimbe, .zimbf, .zimbg, .zimbh, .zimbi, .zimbj, .zimbk, .zimbl, .zimbm, .zimbn, .zimbo, .zimbp, .zimbq, .zimbr, .zimbs, .zimbt, .zimbu, .zimbv, .zimbw, .zimbx, .zimby, .zimbz" />
                                 </div>
-                                <div class="row">
-                                    <div class="col-xs-12">
-                                        <p style="padding-top:0.5em;"><strong>Only Wikimedia contents (wiki*.zim* files)</strong> have been tested well with this app.</p>
-                                    </div>
+                                <div id="instructions" class="row">
+                                    <p>
+                                        Please choose the location of your ZIM archive <b>or drag-and-drop the file(s) here</b>.<br />
+                                        For a split archive (.zimaa, .zimab, etc.) you must select <b>all</b> the split parts.
+                                    </p>
                                 </div>
                             </div>
                             <div id="rescanStorage" style="display:none;" class="row">

--- a/www/index.html
+++ b/www/index.html
@@ -736,8 +736,7 @@
                                     </div>
                                 </div>
                                 <div class="row" style="padding-bottom: 0.5em;">
-                                    <input type="file" class="btn btn-primary btn-inline" value="Select folder with ZIM files" id="archiveFilesLegacy" multiple 
-                                        accept="application/x-zim,.zim,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz, .zimba, .zimbb, .zimbc, .zimbd, .zimbe, .zimbf, .zimbg, .zimbh, .zimbi, .zimbj, .zimbk, .zimbl, .zimbm, .zimbn, .zimbo, .zimbp, .zimbq, .zimbr, .zimbs, .zimbt, .zimbu, .zimbv, .zimbw, .zimbx, .zimby, .zimbz" />
+                                    <input type="file" class="btn btn-primary btn-inline" value="Select folder with ZIM files" id="archiveFilesLegacy" multiple />
                                 </div>
                                 <div id="instructions" class="row">
                                     <p>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -616,6 +616,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             } else {
                 displayFileSelect();
             }
+            document.getElementById('rescanStorage').style.display = 'none';
         });
         // Bottom bar :
         // @TODO Since bottom bar now hidden in Settings and About the returntoArticle code cannot be accessed;
@@ -1011,10 +1012,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                 document.getElementById('archiveFiles').style.display = 'none';
                 document.getElementById('UWPInstructions').style.display = 'none';
                 document.getElementById('archivesFound').style.display = 'none';
-                document.getElementById('instructions').style.display = 'block';
+                if (!appstate.selectedArchive) document.getElementById('instructions').style.display = 'block';
                 document.getElementById('archiveFilesLegacy').style.display = 'block';
-                document.getElementById('archiveFilesLegacy').addEventListener('change', setLocalArchiveFromFileSelect);
                 document.getElementById('btnRefresh').style.display = 'none';
+            } else {
+                document.getElementById('archiveFilesLegacy').style.display = 'none';
             }
             document.getElementById('chooseArchiveFromLocalStorage').style.display = "block";
             // If user had previously picked a file using Native FS, offer to re-open
@@ -1145,12 +1147,15 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             }, 0);
         }
 
+        // Legacy file picker is used as a fallback when all other pickers are unavailable
+        document.getElementById('archiveFilesLegacy').addEventListener('change', setLocalArchiveFromFileSelect);
+        // But in preference, use UWP, File System Access API        
         document.getElementById('archiveFile').addEventListener('click', function () {
             if (typeof Windows !== 'undefined' && typeof Windows.Storage !== 'undefined') {
                 //UWP FilePicker
                 pickFileUWP();
             } else if (typeof window.showOpenFilePicker === 'function') {
-                // Native File System API file picker
+                // File System Access API file picker
                 pickFileNativeFS();
             } else if (window.fs && window.dialog) {
                 // Electron file picker if showOpenFilePicker is not available
@@ -3315,7 +3320,11 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                         params.rescan = false;
                     }, 100);
                 } else {
-                    document.getElementById('openLocalFiles').style.display = 'none';
+                    if (typeof Windows === 'undefined' && typeof window.showOpenFilePicker !== 'function' && !window.dialog) {
+                        document.getElementById('instructions').style.display = 'none';
+                    } else {
+                        document.getElementById('openLocalFiles').style.display = 'none';
+                    }
                     document.getElementById('usage').style.display = 'none';
                     if (params.rememberLastPage && ~params.lastPageVisit.indexOf(params.storedFile.replace(/\.zim(\w\w)?$/, ''))) {
                         var lastPage = params.lastPageVisit.replace(/@kiwixKey@.+/, "");


### PR DESCRIPTION
This may address #361, but needs to be merged in order to test on BroswerStack before we can be sure. In any case, it's a great improvement with the legacy file picker even on IE11 and Firefox (much quicker and smoother to select an archive).