### PR TITLE
Fix breakout link regression and rename feature

### DIFF
--- a/www/article.html
+++ b/www/article.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="Content-Security-Policy" content="default-src data: blob: about: chrome-extension: ms-appx-web: 'unsafe-inline' 'unsafe-eval';">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: blob: file: about: chrome-extension: ms-appx-web: 'unsafe-inline' 'unsafe-eval';">
         <meta name="description" content="Placeholder for injecting an article into the iframe or window">
     </head>
     <body></body>

--- a/www/article.html
+++ b/www/article.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="Content-Security-Policy" content="default-src http: https: file: data: blob: chrome-extension: ms-appx-web: 'unsafe-inline' 'unsafe-eval';">
+        <meta http-equiv="Content-Security-Policy" content="default-src data: blob: about: chrome-extension: ms-appx-web: 'unsafe-inline' 'unsafe-eval';">
         <meta name="description" content="Placeholder for injecting an article into the iframe or window">
     </head>
     <body></body>

--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
     <title>Kiwix JS PWA</title>
     <meta name="description" content="Offline Wikipedia reader">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: https://download.kiwix.org https://master.download.kiwix.org https://pwa.kiwix.org https://kiwix.github.io https://api.github.com 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension: chrome-extension:; object-src 'none';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: about: https://download.kiwix.org https://master.download.kiwix.org https://pwa.kiwix.org https://kiwix.github.io https://api.github.com 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension: chrome-extension:; object-src 'none';">
     <meta name="theme-color" content="black">
     <!--
     Kiwix (offline Wikipedia reader) - HTML5/Javascript version

--- a/www/index.html
+++ b/www/index.html
@@ -512,9 +512,9 @@
                     <p>
                         You can <b>download images</b> (as long as they haven't been inserted dynamically) by turning on the option <b>Allow image manipulation</b> in Configuration. Then you will be
                         able to right-click an image and save it to disk or open it in a new tab (only tested in Wikimedia ZIMs). However, <b><i>this doesn't work in the UWP or NWJS apps</i></b>. Workaround
-                        for the UWP app: you can enable the <b>Insert breakout link</b> option, export the article to a new browser tab (by clicking the Breakout link), and then you will be able to manipulate
-                        images in the browser tab. Please note that enabling Image manipulation or the Breakout link feature can interfere badly with some ZIMs that rely heavily on active content. So turn
-                        these options off if you are using such ZIMs.
+                        for the UWP app: you can enable the <b>Download or open current article</b> (breakout link) option, export the article to a new browser tab (by clicking the Breakout icon), and then
+                        you will be able to manipulate images in the browser tab. Please note that enabling Image manipulation or the Download/ feature can interfere badly with some ZIMs that rely heavily on
+                        active content. So turn these options off if you are using such ZIMs.
                     </p>
                     <p>
                         You can <b>download EPUBs and PDFs</b>, e.g. from Gutenberg ZIMs, in JQuery mode, but the proprietary User Interface doesn't work (use title search instead). In the UWP Desktop app
@@ -530,8 +530,8 @@
                     <h3 id="windows">Window and tab management</h3>
                     <p>
                         You can <b>open ZIM links in a new browsable tab (or window)</b> by setting the options in Configuration. Right-click (or double right-click if you set that option), ctrl-click, middle click
-                        and long press should all work. Somne contexts (e.g. mobile) don't support this option, or it works badly or very slowly. For those contexts, use the <b>Insert breakout link</b> feature
-                        instead. With the Breakout link feature, the tab is non-browsable, but you can save the page to PDF or print it, etc., from that tab.
+                        and long press should all work. Somne contexts (e.g. mobile) don't support this option, or it works badly or very slowly. For those contexts, use the <b>Download or open current article</b> feature
+                        instead. With this feature, the tab is non-browsable, but you can save the page to PDF or print it, etc., from that tab.
                     </p>
                     <p>
                         <b><i>Help! - when I click on an external link it gets blocked!</i></b> Don't panic, this is the Content Security Policy potecting you. You have probably activated Service Worker mode. To open
@@ -985,10 +985,10 @@
                                             </div>
                                         </div>
                                         <div id="winOpenerHelp" style="padding-bottom:1em;"></div>
-                                        <label class="checkbox">
+                                        <label class="checkbox" title="Inserts an icon at the top of an article which allows you to download or open the article, with all its images, in a new window or tab. The article will be saved as a self-contained HTML file, which you can open in any browser.">
                                             <input type="checkbox" name="allowHTMLExtraction" id="allowHTMLExtractionCheck">
                                             <span class="checkmark"></span>
-                                            <b>Add breakout link to open <i>current</i> article in new (non-browsable) window</b> (supported by most browsers: <i>disable popup blocking!</i>)
+                                            <b>Download or open <i>current</i> article via breakout icon</b> (self-contained, but not browsable)
                                         </label>
                                         <label class="checkbox">
                                             <input type="checkbox" name="openAllSections" id="openAllSectionsCheck">

--- a/www/index.html
+++ b/www/index.html
@@ -6,7 +6,7 @@
     <title>Kiwix JS PWA</title>
     <meta name="description" content="Offline Wikipedia reader">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: about: https://download.kiwix.org https://master.download.kiwix.org https://pwa.kiwix.org https://kiwix.github.io https://api.github.com 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension: chrome-extension:; object-src 'none';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data: file: about: https://download.kiwix.org https://master.download.kiwix.org https://pwa.kiwix.org https://kiwix.github.io https://api.github.com 'unsafe-inline' 'unsafe-eval'; frame-src 'self' moz-extension: chrome-extension:; object-src 'none';">
     <meta name="theme-color" content="black">
     <!--
     Kiwix (offline Wikipedia reader) - HTML5/Javascript version

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1334,7 +1334,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             if (this.checked && !params.displayHiddenBlockElements && !params.noWarning) {
                 if (/UWP/.test(params.appType)) {
                     uiUtil.systemAlert('<p><b>WORKAROUND FOR UWP APP:</b> To save an image to disk, please select the ' +
-                    '"Download or open current article" option below, load the article you require, and export it to a browser window by clicking the breakout icon.</p>' +
+                        '"Download or open current article" option below, load the article you require, and export it to a browser window by clicking the breakout icon.</p>' +
                         '<p>You will then be able to right-click or long-press images in the exported page and save them.</p>');
                 } else if (window.nw) {
                     uiUtil.systemAlert('Unfortunately there is currently no way to save an image to disk in the NWJS version of this app.<br>You can do this in the PWA version: please visit https://pwa.kiwix.org.');
@@ -1491,7 +1491,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             if (params.windowOpener && /UWP\|PWA/.test(params.appType) && params.contentInjectionMode === 'jquery') {
                 uiUtil.systemAlert('<p>In this UWP app, opening a new browsable window only works in Service Worker mode.</p>' + 
                     '<p>Your system appears to support SW mode, so please try switching to it in Expert Settings below.</p>' +
-                '<p>If your system does not support SW mode, then use the more basic "Download or open current article" feature below.</p>');
+                    '<p>If your system does not support SW mode, then use the more basic "Download or open current article" feature below.</p>');
                 paams.windowOpener = false;
             } else if (params.windowOpener && /iOS|UWP$/.test(params.appType)) {
                 uiUtil.systemAlert('This option is not currently supported ' + (/iOS/.test(params.appType) ? 'on iOS devices because tabs and windows are isolated.' :
@@ -1501,7 +1501,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                 settingsStore.setItem('windowOpener', params.windowOpener, Infinity);
             }
             if (params.windowOpener && params.allowHTMLExtraction) {
-            uiUtil.systemAlert('Enabling this option disables the more basic "Download or open current article" option below.');
+                uiUtil.systemAlert('Enabling this option disables the more basic "Download or open current article" option below.');
                 document.getElementById('allowHTMLExtractionCheck').click();
             }
             setWindowOpenerUI();
@@ -4761,19 +4761,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             params.containsMathTex = params.useMathJax ? /<(script|span)\s+(type|class)\s*=\s*['"]\s*(math\/tex|latex)\s*['"]/i.test(htmlArticle) : false;
             params.containsMathSVG = params.useMathJax ? /<img\s+(?=[^>]+?math-fallback-image)[^>]*?alt\s*=\s*['"][^'"]+[^>]+>/i.test(htmlArticle) : false;
 
-            // if (params.useMathJax && params.containsMathTex) {
-            //     // Proofwiki blocks
-            //     htmlArticle = htmlArticle.replace(/(<(?:dd|td|span)\b[^>]*>)((?:\$|\\)(?:[^<]|<(?!\/(?:dd|td|span)))+)(<\/(?:dd|td|span)>)/ig, function (m0, left, math, right) {
-            //         // math = math.replace(/\\ds\s/g, '\\displaystyle ');
-            //         math = math.replace(/\\map\s/g, '\\mapsto ');
-            //         return left + math + right;
-            //     });
-            // }
-
             // Add CSP to prevent external scripts and content - note that any existing CSP can only be hardened, not loosened
-            // if (!/<meta\b[^>]+Content-Security-Policy/i.test(htmlArticle)) {
             htmlArticle = htmlArticle.replace(/(<head\b[^>]*>)\s*/, '$1\n    <meta http-equiv="Content-Security-Policy" content="default-src \'self\' data: file: blob: bingmaps: about: \'unsafe-inline\' \'unsafe-eval\';"></meta>\n    ');
-            // }
 
             // Maker return links
             uiUtil.makeReturnLink(dirEntry.getTitleOrUrl());

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1243,7 +1243,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             if (this.value === 'serviceworker') {
                 if (params.manipulateImages || params.allowHTMLExtraction) {
                     if (!appstate.wikimediaZimLoaded) {
-                    var message = 'Please note that we are disabling "Image manipulation" and/or "Download or open current article" features, as these options ' +
+                        var message = 'Please note that we are disabling "Image manipulation" and/or "Download or open current article" features, as these options ' +
                         'can interfere with ZIMs that have active content. You may turn them back on, but be aware that they are only ' + 
                         'recommended for use with Wikimedia ZIMs.';
                         uiUtil.systemAlert(message);
@@ -1495,7 +1495,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                 paams.windowOpener = false;
             } else if (params.windowOpener && /iOS|UWP$/.test(params.appType)) {
                 uiUtil.systemAlert('This option is not currently supported ' + (/iOS/.test(params.appType) ? 'on iOS devices because tabs and windows are isolated.' :
-                'in UWP apps that cannot use Service Worker mode.') + '<br>Please switch to the more basic "Download or open current article" feature below instead.');
+                    'in UWP apps that cannot use Service Worker mode.') + '<br>Please switch to the more basic "Download or open current article" feature below instead.');
                 params.windowOpener = false;
             } else {
                 settingsStore.setItem('windowOpener', params.windowOpener, Infinity);
@@ -1562,8 +1562,8 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                     alertMessage = '<p><b>This option will only work if you turn off popup blocking in your iOS browser settings.</b><p>';
                 }
                 if (params.contentInjectionMode === 'serviceworker') {
-                alertMessage = '<p>Please be aware that the "Download or open current article" functionality can interfere badly with non-Wikimedia ZIMs (particularly ZIMs that have active content). ' + 
-                    'If you cannot access the articles in such a ZIM, please turn this setting off.</p>' + alertMessage;
+                    alertMessage = '<p>Please be aware that the "Download or open current article" functionality can interfere badly with non-Wikimedia ZIMs (particularly ZIMs that have active content). ' + 
+                        'If you cannot access the articles in such a ZIM, please turn this setting off.</p>' + alertMessage;
                 } else if (/PWA/.test(params.appType)) {
                     alertMessage += '<p>Be aware that this option may interfere with active content if you switch to Service Worker mode.</p>';
                 }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1243,7 +1243,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             if (this.value === 'serviceworker') {
                 if (params.manipulateImages || params.allowHTMLExtraction) {
                     if (!appstate.wikimediaZimLoaded) {
-                        var message = 'Please note that we are disabling Image manipulation and/or Breakout link, as these options ' +
+                    var message = 'Please note that we are disabling "Image manipulation" and/or "Download or open current article" features, as these options ' +
                         'can interfere with ZIMs that have active content. You may turn them back on, but be aware that they are only ' + 
                         'recommended for use with Wikimedia ZIMs.';
                         uiUtil.systemAlert(message);
@@ -1334,7 +1334,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             if (this.checked && !params.displayHiddenBlockElements && !params.noWarning) {
                 if (/UWP/.test(params.appType)) {
                     uiUtil.systemAlert('<p><b>WORKAROUND FOR UWP APP:</b> To save an image to disk, please select the ' +
-                        '"Add breakout link ..." option below, load the article you require, and export it to a browser window by clicking the breakout link.</p>' +
+                    '"Download or open current article" option below, load the article you require, and export it to a browser window by clicking the breakout icon.</p>' +
                         '<p>You will then be able to right-click or long-press images in the exported page and save them.</p>');
                 } else if (window.nw) {
                     uiUtil.systemAlert('Unfortunately there is currently no way to save an image to disk in the NWJS version of this app.<br>You can do this in the PWA version: please visit https://pwa.kiwix.org.');
@@ -1491,17 +1491,17 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
             if (params.windowOpener && /UWP\|PWA/.test(params.appType) && params.contentInjectionMode === 'jquery') {
                 uiUtil.systemAlert('<p>In this UWP app, opening a new browsable window only works in Service Worker mode.</p>' + 
                     '<p>Your system appears to support SW mode, so please try switching to it in Expert Settings below.</p>' +
-                    '<p>If your system does not support SW mode, then use the more basic "breakout link" feature below.</p>');
+                '<p>If your system does not support SW mode, then use the more basic "Download or open current article" feature below.</p>');
                 paams.windowOpener = false;
             } else if (params.windowOpener && /iOS|UWP$/.test(params.appType)) {
                 uiUtil.systemAlert('This option is not currently supported ' + (/iOS/.test(params.appType) ? 'on iOS devices because tabs and windows are isolated.' :
-                    'in UWP apps that cannot use Service Worker mode.') + '<br>Please switch to the more basic "breakout link" feature below instead.');
+                'in UWP apps that cannot use Service Worker mode.') + '<br>Please switch to the more basic "Download or open current article" feature below instead.');
                 params.windowOpener = false;
             } else {
                 settingsStore.setItem('windowOpener', params.windowOpener, Infinity);
             }
             if (params.windowOpener && params.allowHTMLExtraction) {
-                uiUtil.systemAlert('Enabling this option disables the more basic breakout link option below.');
+            uiUtil.systemAlert('Enabling this option disables the more basic "Download or open current article" option below.');
                 document.getElementById('allowHTMLExtractionCheck').click();
             }
             setWindowOpenerUI();
@@ -1562,7 +1562,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
                     alertMessage = '<p><b>This option will only work if you turn off popup blocking in your iOS browser settings.</b><p>';
                 }
                 if (params.contentInjectionMode === 'serviceworker') {
-                    alertMessage = '<p>Please be aware that the Breakout link functionality can interfere badly with non-Wikimedia ZIMs (particularly ZIMs that have active content). ' + 
+                alertMessage = '<p>Please be aware that the "Download or open current article" functionality can interfere badly with non-Wikimedia ZIMs (particularly ZIMs that have active content). ' + 
                     'If you cannot access the articles in such a ZIM, please turn this setting off.</p>' + alertMessage;
                 } else if (/PWA/.test(params.appType)) {
                     alertMessage += '<p>Be aware that this option may interfere with active content if you switch to Service Worker mode.</p>';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4772,7 +4772,7 @@ define(['jquery', 'zimArchiveLoader', 'uiUtil', 'util', 'utf8', 'cache', 'images
 
             // Add CSP to prevent external scripts and content - note that any existing CSP can only be hardened, not loosened
             // if (!/<meta\b[^>]+Content-Security-Policy/i.test(htmlArticle)) {
-                htmlArticle = htmlArticle.replace(/(<head\b[^>]*>)\s*/, '$1\n    <meta http-equiv="Content-Security-Policy" content="default-src \'self\' data: blob: bingmaps: about: \'unsafe-inline\' \'unsafe-eval\';"></meta>\n    ');
+            htmlArticle = htmlArticle.replace(/(<head\b[^>]*>)\s*/, '$1\n    <meta http-equiv="Content-Security-Policy" content="default-src \'self\' data: file: blob: bingmaps: about: \'unsafe-inline\' \'unsafe-eval\';"></meta>\n    ');
             // }
 
             // Maker return links

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -353,7 +353,7 @@ define(rqDef, function(util) {
                 '<a id="hbeModeLink" href="#displayHiddenBlockElementsDiv" class="alert-link">disable Display hidden block elements</a> ' :
                 params.manipulateImages ? '<a id="imModeLink" href="#imageManipulationDiv" class="alert-link">disable Image manipulation</a> ' : '') + 
                 (params.allowHTMLExtraction ? (params.displayHiddenBlockElements || params.manipulateImages ? 'and ' : '') + 
-                'disable Breakout link ' : '') + 'for this content to work properly. To use Archive Index type a <b><i>space</i></b> ' +
+                'disable Breakout icon ' : '') + 'for this content to work properly. To use Archive Index type a <b><i>space</i></b> ' +
                 'in the box above, or <b><i>space / </i></b> for URL Index.&nbsp;[<a id="stop" href="#expertSettingsDiv" class="alert-link">Permanently hide</a>]' +
             '</div>';
         }

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -563,12 +563,11 @@ define(rqDef, function(util) {
         div.innerHTML = '<a href="#"><img id="breakoutLink" src="' + prefix + '/img/icons/' + (mode == 'light' ? 'new_window.svg' : 'new_window_lb.svg') + '" width="30" height="30" alt="' + desc + '" title="' + desc + '"></a>';
         iframe.body.insertBefore(div, iframe.body.firstChild);
         var openInTab = iframe.getElementById('openInTab');
-        // Have to use jQuery here becasue e.preventDefault is not working properly in some browsers
-        $(openInTab).on('click', function() {
+        openInTab.addEventListener('click', function(e) {
+            e.preventDefault();
             itemsCount = false;
             params.preloadingAllImages = false;
             extractHTML();
-            return false;
         });
     }
     

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -481,6 +481,7 @@ define(rqDef, function(util) {
         alertMessage.innerHTML = '<strong>Download</strong> If the download does not start, please tap the following link: ';
         // We have to add the anchor to a UI element for Firefox to be able to click it programmatically: see https://stackoverflow.com/a/27280611/9727685
         alertMessage.appendChild(a);
+        var downloadAlert = document.getElementById('downloadAlert');
         // For IE11 we need to force use of the saveBlob method with the onclick event 
         if (window.navigator && window.navigator.msSaveBlob) {
             a.addEventListener('click', function (e) {
@@ -491,7 +492,7 @@ define(rqDef, function(util) {
         try {
             a.click();
             // Following line should run only if there was no error, leaving the alert showing in case of error
-            if (autoDismiss) $('#downloadAlert').alert('close');
+            if (autoDismiss && downloadAlert) downloadAlert.style.display = 'none';
             return;
         }
         catch (err) {
@@ -501,13 +502,13 @@ define(rqDef, function(util) {
         try {
             a.click();
             // Following line should run only if there was no error, leaving the alert showing in case of error
-            if (autoDismiss) $('#downloadAlert').alert('close');
+            if (autoDismiss && downloadAlert) downloadAlert.style.display = 'none';
         }
         catch (err) {
             // And try to launch through UWP download
-            if (Windows && Windows.Storage) {
+            if (typeof Windows !== 'undefined' && Windows.Storage) {
                 downloadBlobUWP(blob, filename, alertMessage);
-                if (autoDismiss) $('#downloadAlert').alert('close');
+                if (autoDismiss && downloadAlert) downloadAlert.style.display = 'none';
             } else {
                 // Last gasp attempt to open automatically
                 window.open(a.href);


### PR DESCRIPTION
Fixes #395 and also renames the feature to "Download or open current article...", which is clearer than "Breakout link".

This is a backport of fix applied to #393.