### PR TITLE
Fix inability to select ZIM archives on latest Chromium for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## In-progress release 2.6.2
+## In-progress release 2.6.3
 
+* REGRESSION: Fixed loss of ability to pick ZIM archives in latest Chromium on Android
 * REGRESSION: Fixed loss of ability to access custom ZIMs from download library
 * REGRESSION: Work around missing titles in English-language Wikivoyage scrapes since 2023-07
 * FIX: Conflict between manual image display and hyperlinking images to high-res Wikimedia versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 * REGRESSION: Fixed loss of ability to access custom ZIMs from download library
 * REGRESSION: Work around missing titles in English-language Wikivoyage scrapes since 2023-07
 * FIX: Conflict between manual image display and hyperlinking images to high-res Wikimedia versions
+* FIX: More broken Linux icons
+* DEV: Appx package is now uploaded to Kiwix releases
 * DEV: Added clear documentation to the Create-DraftRelease.ps1 script
+* DEV: Remove more unnecessary JQuery from the app
 
 ## Release 2.5.6
 

--- a/package-github.appxmanifest
+++ b/package-github.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap3 uap5">
-  <Identity Name="Kiwix.KiwixJS" Version="2.6.2.0" Publisher="CN=Association Kiwix, O=Association Kiwix, L=Lausanne, C=CH" />
+  <Identity Name="Kiwix.KiwixJS" Version="2.6.22.0" Publisher="CN=Association Kiwix, O=Association Kiwix, L=Lausanne, C=CH" />
   <mp:PhoneIdentity PhoneProductId="9983be8d-4e36-4018-bfb3-5170659bf447" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Kiwix JS</DisplayName>

--- a/package-github.appxmanifest
+++ b/package-github.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap3 uap5">
-  <Identity Name="Kiwix.KiwixJS" Version="2.6.22.0" Publisher="CN=Association Kiwix, O=Association Kiwix, L=Lausanne, C=CH" />
+  <Identity Name="Kiwix.KiwixJS" Version="2.6.3.0" Publisher="CN=Association Kiwix, O=Association Kiwix, L=Lausanne, C=CH" />
   <mp:PhoneIdentity PhoneProductId="9983be8d-4e36-4018-bfb3-5170659bf447" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Kiwix JS</DisplayName>

--- a/package.appxmanifest
+++ b/package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap3 uap5">
-  <Identity Name="Kiwix.KiwixJS" Version="2.6.2.0" Publisher="CN=0A5438F5-EEA6-4300-9B77-E45BBD148885" />
+  <Identity Name="Kiwix.KiwixJS" Version="2.6.22.0" Publisher="CN=0A5438F5-EEA6-4300-9B77-E45BBD148885" />
   <mp:PhoneIdentity PhoneProductId="9983be8d-4e36-4018-bfb3-5170659bf447" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Kiwix JS</DisplayName>

--- a/package.appxmanifest
+++ b/package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap3 uap5">
-  <Identity Name="Kiwix.KiwixJS" Version="2.6.22.0" Publisher="CN=0A5438F5-EEA6-4300-9B77-E45BBD148885" />
+  <Identity Name="Kiwix.KiwixJS" Version="2.6.3.0" Publisher="CN=0A5438F5-EEA6-4300-9B77-E45BBD148885" />
   <mp:PhoneIdentity PhoneProductId="9983be8d-4e36-4018-bfb3-5170659bf447" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Kiwix JS</DisplayName>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kiwix-js-electron",
   "productName": "Kiwix JS Electron",
-  "version": "2.6.22-E",
+  "version": "2.6.3-E",
   "description": "Kiwix JS offline ZIM archive reader packaged for the Electron framework",
   "main": "main.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kiwix-js-electron",
   "productName": "Kiwix JS Electron",
-  "version": "2.6.2-E",
+  "version": "2.6.22-E",
   "description": "Kiwix JS offline ZIM archive reader packaged for the Electron framework",
   "main": "main.cjs",
   "type": "module",

--- a/package.json.nwjs
+++ b/package.json.nwjs
@@ -1,7 +1,7 @@
 {
   "name": "kiwix_js_windows",
   "productName": "Kiwix JS Windows",
-  "version": "2.6.22-N",
+  "version": "2.6.3-N",
   "description": "Kiwix JS Windows for NWJS",
   "main": "index.html",
   "domain": "kiwix.js.windows",

--- a/package.json.nwjs
+++ b/package.json.nwjs
@@ -1,7 +1,7 @@
 {
   "name": "kiwix_js_windows",
   "productName": "Kiwix JS Windows",
-  "version": "2.6.2-N",
+  "version": "2.6.22-N",
   "description": "Kiwix JS Windows for NWJS",
   "main": "index.html",
   "domain": "kiwix.js.windows",

--- a/scripts/Build-NWJS.ps1
+++ b/scripts/Build-NWJS.ps1
@@ -12,7 +12,7 @@ if (-Not $only32bit) {
 }
 $version10 = "0.72.0" # <<< value updated automatically from package.json if launched from Create-DraftRelease
 $versionXP = "0.14.7"
-$appBuild = "2.6.22-N" # <<< value updated auotmatically from package.json if launched from Create-DraftRelease
+$appBuild = "2.6.3-N" # <<< value updated auotmatically from package.json if launched from Create-DraftRelease
 # Check that the dev has included the correct archive in this branch
 $init_params = Get-Content -Raw "$PSScriptRoot\..\dist\www\js\init.js"
 $PackagedArchive = $init_params -imatch 'params\[.packagedFile.][^;]+?[''"]([^\s]+?\.zim)[''"];'

--- a/scripts/Build-NWJS.ps1
+++ b/scripts/Build-NWJS.ps1
@@ -12,7 +12,7 @@ if (-Not $only32bit) {
 }
 $version10 = "0.72.0" # <<< value updated automatically from package.json if launched from Create-DraftRelease
 $versionXP = "0.14.7"
-$appBuild = "2.6.2-N" # <<< value updated auotmatically from package.json if launched from Create-DraftRelease
+$appBuild = "2.6.22-N" # <<< value updated auotmatically from package.json if launched from Create-DraftRelease
 # Check that the dev has included the correct archive in this branch
 $init_params = Get-Content -Raw "$PSScriptRoot\..\dist\www\js\init.js"
 $PackagedArchive = $init_params -imatch 'params\[.packagedFile.][^;]+?[''"]([^\s]+?\.zim)[''"];'

--- a/service-worker.js
+++ b/service-worker.js
@@ -29,7 +29,7 @@
  * download and install a new copy; we have to hard code this here because it is needed before any other file
  * is cached in APP_CACHE
  */
-const appVersion = '2.6.2';
+const appVersion = '2.6.22';
 
 /**
  * The name of the Cache API cache in which assets defined in regexpCachedContentTypes will be stored

--- a/service-worker.js
+++ b/service-worker.js
@@ -29,7 +29,7 @@
  * download and install a new copy; we have to hard code this here because it is needed before any other file
  * is cached in APP_CACHE
  */
-const appVersion = '2.6.22';
+const appVersion = '2.6.3';
 
 /**
  * The name of the Cache API cache in which assets defined in regexpCachedContentTypes will be stored

--- a/www/index.html
+++ b/www/index.html
@@ -106,7 +106,10 @@
                                 <li>Fixed regression preventing access to custom ZIM archives in download library</li>
                                 <li>Work around missing titles in English-language Wikivoyage scrapes since 2023-07</li>
                                 <li>Fix conflict between manual image display and hyperlinking images to high-res Wikimedia versions</li>
+                                <li>Fix more broken Linux icons</li>
+                                <li>Appx package is now uploaded to Kiwix releases</li>
                                 <li>Added clear documentation to the Create-DraftRelease.ps1 script</li>
+                                <li>Remove more unnecessary JQuery from the app</li>
                             </ul>
                             <p><a href="https://github.com/kiwix/kiwix-js-windows/blob/main/CHANGELOG.md" target="_blank" rel="noopener">And there's more...<img alt="external link" src="I/s/Icon_External_Link.png"></a></p>
                         </div>

--- a/www/index.html
+++ b/www/index.html
@@ -102,31 +102,11 @@
                         <div id="update" class="update">
                             <h3 style="margin-top:0;">Changes in version <span class="version">2.0</span></h3>
                             <ul style="padding-left: 15px;">
+                                <li>Fixed loss of ability to pick ZIM archives in latest Chromium on Android</li>
                                 <li>Fixed regression preventing access to custom ZIM archives in download library</li>
                                 <li>Work around missing titles in English-language Wikivoyage scrapes since 2023-07</li>
                                 <li>Fix conflict between manual image display and hyperlinking images to high-res Wikimedia versions</li>
-                                <li>Ability to pick a folder of ZIM archives in nearly all apps and frameworks supporting the Webkitdirectory API</li>
-                                <li>New Electron-based appx version of Kiwix JS now served from the Microsoft Store and from GitHub Releases</li>
-                                <li>The Electron app is registerd as the default app for handling .zim or .zimaa archive files on Windows and Linux</li>
-                                <li>Improved file and folder picking experience for Firefox and older browsers lacking the File System Access API</li>
-                                <li>Fast re-opening of previously picked archives or directories in these browsers (number of clicks minimized)</li>
-                                <li>Dragged and dropped files, including split files, can now be re-opened automatically in Electron and NWJS apps</li>
-                                <li>Microsoft Store app now supports full-text search for users with 64bit Windows</li>
-                                <li>Provide more gradual screen width transition with max page width auto setting</li>
-                                <li>Restored the ability not to display images in ServiceWorker Mode in non-Zimit ZIMs</li>
-                                <li>Restored lazy-loading of images on most landing pages (improves Android experience with image-heavy landing pages)</li>
-                                <li>The Kiwix PWA can now be added as a Side Panel app in Edge (folder picking does not work in this configuration)</li>
-                                <li>Top toolbar now resized correctly with Window Controls Overlay in installed PWA on macOS and Windows</li>
-                                <li>When using Window Controls Overlay, app now has a draggable area (left of Kiwix icon)</li>
-                                <li>Sample archive changed to wikipedia_en_100_mini_2023-07</li>
-                                <li>Troubleshooting instructions for installing on Debian on the Releases page</li>
-                                <li>Allow producing signed or unsigned versions of appx, and compile to appxbundle</li>
-                                <li>Option to build artefacts only for testing</li>
-                                <li>Fixed broken Kiwix icon for Linux app packages</li>
-                                <li>Improved fidelity of layout for translation tables in cached Wiktionary mobile and desktop styles</li>
-                                <li>Fixed broken file handling in legacy UWP app</li>
-                                <li>Miscellaneous small bugfixes and typos</li>
-                                <li>A lot of normalization of coding style using ESLint</li>
+                                <li>Added clear documentation to the Create-DraftRelease.ps1 script</li>
                             </ul>
                             <p><a href="https://github.com/kiwix/kiwix-js-windows/blob/main/CHANGELOG.md" target="_blank" rel="noopener">And there's more...<img alt="external link" src="I/s/Icon_External_Link.png"></a></p>
                         </div>

--- a/www/index.html
+++ b/www/index.html
@@ -756,7 +756,7 @@
                                 </div>
                                 <div id="archiveFilesLegacyDiv">
                                     <div class="row" style="padding-bottom: 0.5em;">
-                                        <input type="file" accept="application/octet-stream"
+                                        <input type="file" accept="application/octet-stream,.zim,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz,.zimba,.zimbb,.zimbc,.zimbd,.zimbe,.zimbf,.zimbg,.zimbh,.zimbi,.zimbj,.zimbk,.zimbl,.zimbm,.zimbn,.zimbo,.zimbp,.zimbq,.zimbr,.zimbs,.zimbt,.zimbu,.zimbv,.zimbw,.zimbx,.zimby,.zimbz"
                                             class="btn btn-primary btn-inline" value="Select folder with ZIM files" id="archiveFilesLegacy" multiple />
                                         <input type="file" class="btn btn-primary btn-inline" value="Select folder" id="archiveDirLegacy" webkitdirectory />
                                     </div>

--- a/www/index.html
+++ b/www/index.html
@@ -756,7 +756,7 @@
                                 </div>
                                 <div id="archiveFilesLegacyDiv">
                                     <div class="row" style="padding-bottom: 0.5em;">
-                                        <input type="file" accept=".zim,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz,.zimba,.zimbb,.zimbc,.zimbd,.zimbe,.zimbf,.zimbg,.zimbh,.zimbi,.zimbj,.zimbk,.zimbl,.zimbm,.zimbn,.zimbo,.zimbp,.zimbq,.zimbr,.zimbs,.zimbt,.zimbu,.zimbv,.zimbw,.zimbx,.zimby,.zimbz"
+                                        <input type="file" accept="application/octet-stream"
                                             class="btn btn-primary btn-inline" value="Select folder with ZIM files" id="archiveFilesLegacy" multiple />
                                         <input type="file" class="btn btn-primary btn-inline" value="Select folder" id="archiveDirLegacy" webkitdirectory />
                                     </div>

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -53,7 +53,7 @@ var params = {};
 var appstate = {};
 
 // ******** UPDATE VERSION IN service-worker.js TO MATCH VERSION AND CHECK PWASERVER BELOW!!!!!!! *******
-params['appVersion'] = '2.6.22'; // DEV: Manually update this version when there is a new release: it is compared to the Settings Store "appVersion" in order to show first-time info, and the cookie is updated in app.js
+params['appVersion'] = '2.6.3'; // DEV: Manually update this version when there is a new release: it is compared to the Settings Store "appVersion" in order to show first-time info, and the cookie is updated in app.js
 // ******* UPDATE THIS ^^^^^^ IN service worker AND PWA-SERVER BELOW !! ********************
 params['packagedFile'] = getSetting('packagedFile') || 'wikipedia_en_100_mini_2023-07.zim'; // For packaged Kiwix JS (e.g. with Wikivoyage file), set this to the filename (for split files, give the first chunk *.zimaa) and place file(s) in default storage
 params['archivePath'] = 'archives'; // The directory containing the packaged archive(s) (relative to app's root directory)

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -53,7 +53,7 @@ var params = {};
 var appstate = {};
 
 // ******** UPDATE VERSION IN service-worker.js TO MATCH VERSION AND CHECK PWASERVER BELOW!!!!!!! *******
-params['appVersion'] = '2.6.2'; // DEV: Manually update this version when there is a new release: it is compared to the Settings Store "appVersion" in order to show first-time info, and the cookie is updated in app.js
+params['appVersion'] = '2.6.22'; // DEV: Manually update this version when there is a new release: it is compared to the Settings Store "appVersion" in order to show first-time info, and the cookie is updated in app.js
 // ******* UPDATE THIS ^^^^^^ IN service worker AND PWA-SERVER BELOW !! ********************
 params['packagedFile'] = getSetting('packagedFile') || 'wikipedia_en_100_mini_2023-07.zim'; // For packaged Kiwix JS (e.g. with Wikivoyage file), set this to the filename (for split files, give the first chunk *.zimaa) and place file(s) in default storage
 params['archivePath'] = 'archives'; // The directory containing the packaged archive(s) (relative to app's root directory)


### PR DESCRIPTION
Fixes #437 by using a generic MIME type in the accept list (`application/octet-stream`).