### PR TITLE
Enable full text search by default on iOS

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1129,13 +1129,14 @@
                                         <span class="checkmark"></span>
                                         <b>Permanently hide active content warning</b> (for experienced users)
                                     </label>
-                                    <b title="You can force the app to use libzim full-text searching if the ZIM has a full-text index. Useful for earlier versions of Android, for example.">Force use of libzim W/ASM for reading full-text index:</b>
+                                    <b title="You can force the app to use libzim full-text searching if the ZIM has a full-text index. Useful for earlier versions of Android, for example.">Force / disable libzim W/ASM for reading full-text index:</b>
                                     <select title="You can force the app to use libzim full-text searching if the ZIM has a full-text index. Useful for earlier versions of Android, for example." name="debugLibzimASM" id="debugLibzimASMDrop" class="dropdown">
                                         <option value="">Default</option>
                                         <option value="wasm">WASM</option>
                                         <option value="asm">ASM</option>
                                         <option value="wasm.dev">WASM debug</option>
                                         <option value="asm.dev">ASM debug</option>
+                                        <option id="libzimDisable" value="disable">Disable</option>
                                     </select>
                                     <p><i>Warning! Disables OS/ZIM checks and may make title search unresponsive!</i></p>
                                     <label class="checkbox" title="In some browsers on some platforms, drag-and-drop may malfunction and make it difficult to select text, and other operations. Disable it here if it is causing issues." >

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1606,7 +1606,7 @@ document.getElementById('debugLibzimASMDrop').addEventListener('change', functio
     var message = '<p>App will reload to apply the new setting.</p>'
     if (event.target.value) {
         message += '<p><i>Please be aware that leaving this override setting on can have anomalous effects, ' +
-        'e.g. the app will no longer check whether the OS supports full-text searching and searches may fail silently.</i></p>'
+        'e.g. the app will no longer check whether the OS supports full-text searching and searches may fail silently.</i></p>';
     }
     uiUtil.systemAlert(message,
         'Developer option!', true).then(function (confirm) {

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -257,6 +257,7 @@ document.getElementById('hideToolbarsState').innerHTML = (params.hideToolbars ==
 document.getElementById('openExternalLinksInNewTabsCheck').checked = params.openExternalLinksInNewTabs;
 document.getElementById('disableDragAndDropCheck').checked = params.disableDragAndDrop;
 document.getElementById('debugLibzimASMDrop').value = params.debugLibzimASM || '';
+if (params.debugLibzimASM === 'disable') document.getElementById('debugLibzimASMDrop').style.color = 'red';
 if (params.windowOpener === null) { // Setting has never been activated, so determine a sensible default
     params.windowOpener = /UWP/.test(params.appType) && params.contentInjectionMode === 'jquery' ? false :
     /iOS/.test(params.appType) ? false :

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -104,7 +104,7 @@ function ZIMArchive (storage, path, callbackReady, callbackError) {
                 var libzimReaderType = params.debugLibzimASM || ('WebAssembly' in self ? 'wasm' : 'asm');
                 if (that._file.fullTextIndex && params.debugLibzimASM !== 'disable' && (params.debugLibzimASM || !isSplitZim &&
                 // The ASM implementation requires Atomics support, whereas the WASM implementation does not
-                (libzimReaderType === 'asm' && typeof Atomics !== 'undefined') &&
+                (typeof Atomics !== 'undefined' || libzimReaderType === 'wasm') &&
                 // Note that Android and NWJS currently throw due to problems with Web Worker context
                 !/Android/.test(params.appType) && !(window.nw && that._file._files[0].readMode === 'electron'))) {
                     console.log('Instantiating libzim ' + libzimReaderType + ' Web Worker...');

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -124,7 +124,7 @@ function ZIMArchive (storage, path, callbackReady, callbackError) {
                         params.searchProvider += ': no_fulltext'; // message += 'this ZIM does not have a full-text index.';
                     } else if (isSplitZim) {
                         params.searchProvider += ': split_zim'; // message += 'the ZIM archive is split.';
-                    } else if (libzimReaderType === 'asm' && typeof Atomics === 'undefined') {
+                    } else if (typeof Atomics === 'undefined') {
                         params.searchProvider += ': no_atomics'; // message += 'this browser does not support Atomic operations.';
                     } else if (/Android/.test(params.appType)) {
                         params.searchProvider += ': no_sharedArrayBuffer';

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -102,7 +102,7 @@ function ZIMArchive (storage, path, callbackReady, callbackError) {
                 // There is currently an exception thrown in the libzim wasm if we attempt to load a split ZIM archive, so we work around
                 var isSplitZim = /\.zima.$/i.test(that._file._files[0].name);
                 var libzimReaderType = params.debugLibzimASM || ('WebAssembly' in self ? 'wasm' : 'asm');
-                if (that._file.fullTextIndex && (params.debugLibzimASM || !isSplitZim &&
+                if (that._file.fullTextIndex && params.debugLibzimASM !== 'disable' && (params.debugLibzimASM || !isSplitZim &&
                 // The ASM implementation requires Atomics support, whereas the WASM implementation does not
                 (libzimReaderType === 'asm' && typeof Atomics !== 'undefined') &&
                 // Note that Android and NWJS currently throw due to problems with Web Worker context
@@ -128,6 +128,10 @@ function ZIMArchive (storage, path, callbackReady, callbackError) {
                         params.searchProvider += ': no_atomics'; // message += 'this browser does not support Atomic operations.';
                     } else if (/Android/.test(params.appType)) {
                         params.searchProvider += ': no_sharedArrayBuffer';
+                    } else if (params.debugLibzimASM === 'disable') {
+                        params.searchProvider += ': disabled';
+                    } else {
+                        params.searchProvider += ': unknown';
                     }
                     uiUtil.reportSearchProviderToAPIStatusPanel(params.searchProvider);
                     // uiUtil.systemAlert(message);


### PR DESCRIPTION
Fixes #445. However, those on iOS 14 and below will have ft-search enabled even though it won't work. I think this is justifiable, because Apple tends to upgrade its users aggressively, so we can expect most to be using iOS 15 and above. The experience is not terrible on older iOS, it's just that searching will try (and fail) to get ft search results once title results return. There is no annoying dialogue box, so I don't think this is too much of an issue.