### PR TITLE
Fix invalid HTML attribute causing Vite parse error

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -276,7 +276,7 @@
         <article class="view-content" id="article">
             <div id="scrollbox" class="container">
                 <div id="about" style="display: none;" class="category-padding">
-                    <div class="returntoArticle""></div>
+                    <div class="returntoArticle"></div>
                     <h2>
                         <img src="img/icons/kiwix-60.png" alt="Kiwix icon" id="kiwixIconAbout" />
                         Kiwix JS <span class="identity">Windows</span>


### PR DESCRIPTION
This PR fixes an invalid HTML attribute in www/index.html where an extra double quote
was causing Vite to fail parsing the file during `npm run serve`.

The issue resulted in the error:
"missing-whitespace-between-attributes"

Removing the extra quote restores valid HTML and allows the development server
to start correctly.