### PR TITLE
Update release/nightly uploads for new destination

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -72,7 +72,7 @@ env:
   ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_USER_TOTP_SECRET }}
   MASTER_KEY_FILE: "C:\\Users\\runneradmin\\eSignerCKA\\master.key"
   INSTALL_DIR: C:\Users\runneradmin\eSignerCKA
-  SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+  SSH_KEY: ${{ secrets.KIWIXJSPWA_FILE_UPLOAD_KEY }}
   REF_NAME: ${{ github.ref_name }}
 
 jobs:

--- a/.github/workflows/publish-appxbundle.yml
+++ b/.github/workflows/publish-appxbundle.yml
@@ -28,7 +28,7 @@ jobs:
       # Set up secret files from encrypted secrets
       - name: Set up secret files
         env:
-          SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+          SSH_KEY: ${{ secrets.KIWIXJSPWA_FILE_UPLOAD_KEY }}
         shell: pwsh
         run: |
           $SSH_KEY = $Env:SSH_KEY

--- a/.github/workflows/safe-retrieval.old
+++ b/.github/workflows/safe-retrieval.old
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Encrypt secret
         env:
-          SSH_KEY: ${{ secrets.KIWIX_FILE_UPLOAD_SSH_KEY }}
+          SSH_KEY: ${{ secrets.KIWIXJSPWA_FILE_UPLOAD_KEY }}
           GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
         run: |
           echo "$GPG_PUBLIC_KEY" | gpg --import

--- a/scripts/Publish-ElectronPackages.ps1
+++ b/scripts/Publish-ElectronPackages.ps1
@@ -151,8 +151,8 @@ if (-not $CRON_LAUNCHED) {
 if (-not $githubonly) {
     "`nUploading packages to https://master.download.kiwix.org$target/ ...`n"
     if (-Not $dryrun) {
-        echo "mkdir $target" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'ci@master.download.kiwix.org')
-        # echo "mkdir $win_target" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'ci@master.download.kiwix.org')
+        echo "mkdir $target" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'kiwix-js-pwa@master.download.kiwix.org')
+        # echo "mkdir $win_target" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'kiwix-js-pwa@master.download.kiwix.org')
     }
     $Packages | % {
         $file = $_
@@ -203,13 +203,13 @@ if (-not $githubonly) {
                 # Replace absolute path with relative, and normalize to forward slashes
                 $renamed_file = $renamed_file -replace '^.*?([\\/]bld)', './dist$1' -replace '[\\/]', '/'
                 "Copying $renamed_file to $target..."
-                & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$renamed_file", "ci@master.download.kiwix.org:$target")
+                & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$renamed_file", "kiwix-js-pwa@master.download.kiwix.org:$target")
                 # DEV: Note that the package is currently uploaded in Push-KiwixRelease, so we don't need to upload it here at this point in time
                 # if (!$CRON_LAUNCHED -and $renamed_file -match '\.appx$') {
                 #     "Also copying $renamed_file to $win_target..."
                 #     $renamed_win_file = $renamed_file -replace 'electron_x86-64', 'windows'
                 #     mv $renamed_file $renamed_win_file
-                #     & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$renamed_win_file", "ci@master.download.kiwix.org:$win_target")
+                #     & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$renamed_win_file", "kiwix-js-pwa@master.download.kiwix.org:$win_target")
                 # }
             }
         }

--- a/scripts/Push-KiwixRelease.ps1
+++ b/scripts/Push-KiwixRelease.ps1
@@ -137,12 +137,12 @@ function Main {
                 $keyfile = "$PSScriptRoot\ssh_key"
                 $keyfile = $keyfile -ireplace '[\\/]', '/'
                 if ($dryrun) {
-                    "C:\Program Files\Git\usr\bin\scp.exe -P 30022 -o StrictHostKeyChecking=no -i $keyfile $filename ci@master.download.kiwix.org:$target"
-                    "echo 'rename $target/$file $target/$newfilename' | C:\Program Files\Git\usr\bin\sftp.exe -P 30022 -o StrictHostKeyChecking=no -i $keyfile ci@master.download.kiwix.org"
+                    "C:\Program Files\Git\usr\bin\scp.exe -P 30322 -o StrictHostKeyChecking=no -i $keyfile $filename kiwix-js-pwa@master.download.kiwix.org:$target"
+                    "echo 'rename $target/$file $target/$newfilename' | C:\Program Files\Git\usr\bin\sftp.exe -P 30322 -o StrictHostKeyChecking=no -i $keyfile kiwix-js-pwa@master.download.kiwix.org"
                 } else {
                     # Uploading file
-                    & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$filename", "ci@master.download.kiwix.org:$target")
-                    echo "rename $target/$file $target/$newfilename" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30022', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'ci@master.download.kiwix.org')
+                    & "C:\Program Files\Git\usr\bin\scp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", "$filename", "kiwix-js-pwa@master.download.kiwix.org:$target")
+                    echo "rename $target/$file $target/$newfilename" | & "C:\Program Files\Git\usr\bin\sftp.exe" @('-P', '30322', '-o', 'StrictHostKeyChecking=no', '-i', "$keyfile", 'kiwix-js-pwa@master.download.kiwix.org')
                     Write-Host "`nDone.`n" -ForegroundColor Green
                 }
             }

--- a/scripts/publish_linux_packages_to_kiwix.sh
+++ b/scripts/publish_linux_packages_to_kiwix.sh
@@ -10,7 +10,7 @@ if [[ "qq${CRON_LAUNCHED}" != "qq" ]]; then
     target="/data/download/nightly/$CURRENT_DATE"
 fi
 echo "Uploading packages to https://download.kiwix.org$target/"
-echo "mkdir ${target}" | sftp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key ci@master.download.kiwix.org
+echo "mkdir ${target}" | sftp -P 30322 -o StrictHostKeyChecking=no -i ./scripts/ssh_key kiwix-js-pwa@master.download.kiwix.org
 for file in ./dist/bld/Electron/* ; do
     if [[ "$file" =~ \.(AppImage|deb|rpm)$ ]]; then
         directory=$(sed -E 's/[^\/]+$//' <<<"$file")
@@ -47,6 +47,6 @@ for file in ./dist/bld/Electron/* ; do
             mv "$file" "$renamed_file"
         fi
         echo "Copying $renamed_file to $target"
-        scp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key "$renamed_file" ci@master.download.kiwix.org:$target
+        scp -P 30322 -o StrictHostKeyChecking=no -i ./scripts/ssh_key "$renamed_file" kiwix-js-pwa@master.download.kiwix.org:$target
     fi
 done

--- a/scripts/publish_macos_packages_to_kiwix.sh
+++ b/scripts/publish_macos_packages_to_kiwix.sh
@@ -10,7 +10,7 @@ if [[ "qq${CRON_LAUNCHED}" != "qq" ]]; then
     target="/data/download/nightly/$CURRENT_DATE"
 fi
 echo "Uploading macOS packages to https://download.kiwix.org$target/"
-echo "mkdir ${target}" | sftp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key ci@master.download.kiwix.org
+echo "mkdir ${target}" | sftp -P 30322 -o StrictHostKeyChecking=no -i ./scripts/ssh_key kiwix-js-pwa@master.download.kiwix.org
 for file in ./dist/bld/Electron/* ; do
     if [[ "$file" =~ \.zip$ ]]; then
         directory=$(sed -E 's/[^\/]+$//' <<<"$file")
@@ -66,6 +66,6 @@ for file in ./dist/bld/Electron/* ; do
             mv "$file" "$renamed_file"
         fi
         echo "Copying $renamed_file to $target"
-        scp -P 30022 -o StrictHostKeyChecking=no -i ./scripts/ssh_key "$renamed_file" ci@master.download.kiwix.org:$target
+        scp -P 30322 -o StrictHostKeyChecking=no -i ./scripts/ssh_key "$renamed_file" kiwix-js-pwa@master.download.kiwix.org:$target
     fi
 done


### PR DESCRIPTION
As part of a server/infra change, the upload of nightly and release builds is done to a new destination.

The receiving service now uses per-project (well per-repo) users with independent SSH Keys. Each users now only has access to the folders in which it is expected to upload files.

- Host remains the same: `master.download.kiwix.org`
- Username changes from `ci` to `kiwix-js-pwa`
- Port changes from `30022` to `30322`
- Paths remains the same

⚠️ DO NOT MERGE ATM