### PR TITLE
feat: allow downloading archives to in-app archives folder for Electr…

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -7,7 +7,8 @@ const { autoUpdater } = require('electron-updater');
 const contextMenu = require('electron-context-menu');
 const fs = require('fs');
 const os = require('os');
-// const https = require('https');
+const https = require('https');
+const http = require('http');
 
 const store = new Store();
 
@@ -274,8 +275,128 @@ if (!gotSingleInstanceLock) {
 //     cert: fs.readFileSync('path/to/your/cert.pem')
 // };
 
+// Track active download requests so they can be cancelled
+const activeDownloads = new Map();
+
 app.whenReady().then(() => {
     server = express()
+
+    // Expose the archives directory path to the renderer
+    // In production (asar-packed), archives are in extraResources (process.resourcesPath)
+    // In development, archives are in the project root (__dirname)
+    var archivesDir = app.isPackaged
+        ? path.join(process.resourcesPath, 'archives')
+        : path.join(__dirname, 'archives');
+
+    ipcMain.handle('get-archives-path', () => {
+        return archivesDir;
+    });
+
+    // Download a ZIM archive directly into the archives folder
+    // Returns a promise that resolves when download completes or rejects on error
+    ipcMain.handle('download-to-archives', async (event, archiveName, archiveUrl) => {
+        // Ensure the archives directory exists
+        if (!fs.existsSync(archivesDir)) {
+            fs.mkdirSync(archivesDir, { recursive: true });
+        }
+        const filePath = path.join(archivesDir, archiveName);
+        const tempPath = filePath + '.download';
+
+        return new Promise((resolve, reject) => {
+            const proto = archiveUrl.startsWith('https') ? https : http;
+            const request = proto.get(archiveUrl, (response) => {
+                // Follow redirects (3xx)
+                if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+                    console.log('Redirecting to: ' + response.headers.location);
+                    // Recurse by invoking the handler logic again via a nested request
+                    const redirectProto = response.headers.location.startsWith('https') ? https : http;
+                    const redirectReq = redirectProto.get(response.headers.location, handleResponse);
+                    redirectReq.on('error', handleError);
+                    activeDownloads.set(archiveName, redirectReq);
+                    return;
+                }
+                handleResponse(response);
+            });
+
+            request.on('error', handleError);
+            activeDownloads.set(archiveName, request);
+
+            function handleResponse (response) {
+                if (response.statusCode !== 200) {
+                    reject(new Error('HTTP error, status = ' + response.statusCode));
+                    return;
+                }
+                const totalBytes = parseInt(response.headers['content-length'], 10) || 0;
+                let receivedBytes = 0;
+                let lastReported = 0;
+                const fileStream = fs.createWriteStream(tempPath);
+
+                response.on('data', (chunk) => {
+                    receivedBytes += chunk.length;
+                    // Report progress every ~512KB to avoid flooding IPC
+                    if (receivedBytes - lastReported >= 524288) {
+                        lastReported = receivedBytes;
+                        if (mainWindow && !mainWindow.isDestroyed()) {
+                            mainWindow.webContents.send('download-to-archives-progress', {
+                                archiveName: archiveName,
+                                receivedBytes: receivedBytes,
+                                totalBytes: totalBytes
+                            });
+                        }
+                    }
+                });
+
+                response.pipe(fileStream);
+
+                fileStream.on('finish', () => {
+                    fileStream.close(() => {
+                        // Rename temp file to final name
+                        try {
+                            if (fs.existsSync(filePath)) {
+                                fs.unlinkSync(filePath);
+                            }
+                            fs.renameSync(tempPath, filePath);
+                            activeDownloads.delete(archiveName);
+                            console.log('Download completed: ' + archiveName);
+                            resolve({ success: true, filePath: filePath });
+                        } catch (err) {
+                            activeDownloads.delete(archiveName);
+                            reject(err);
+                        }
+                    });
+                });
+
+                fileStream.on('error', (err) => {
+                    // Clean up temp file on write error
+                    try { fs.unlinkSync(tempPath); } catch (e) { /* ignore */ }
+                    activeDownloads.delete(archiveName);
+                    reject(err);
+                });
+            }
+
+            function handleError (err) {
+                // Clean up temp file on network error
+                try { fs.unlinkSync(tempPath); } catch (e) { /* ignore */ }
+                activeDownloads.delete(archiveName);
+                reject(err);
+            }
+        });
+    });
+
+    // Cancel an in-progress download
+    ipcMain.handle('cancel-download-to-archives', async (event, archiveName) => {
+        const request = activeDownloads.get(archiveName);
+        if (request) {
+            request.destroy();
+            activeDownloads.delete(archiveName);
+            // Clean up the temp file
+            const tempPath = path.join(archivesDir, archiveName + '.download');
+            try { fs.unlinkSync(tempPath); } catch (e) { /* ignore */ }
+            console.log('Download cancelled: ' + archiveName);
+            return { success: true };
+        }
+        return { success: false, error: 'No active download found for ' + archiveName };
+    });
 
     // Add security headers
     server.use((req, res, next) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-n": "^16.0.0",
         "eslint-plugin-promise": "^6.1.1",
+        "playwright": "^1.59.1",
         "rollup": "^4.59.0",
         "rollup-plugin-copy": "^3.4.0",
         "vite": "^6.4.2"
@@ -9602,6 +9603,53 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -18331,6 +18379,31 @@
           "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
         }
       }
+    },
+    "playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.59.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true
     },
     "plist": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
       "buildResources": "../electron_icons"
     },
     "win": {
-        "signtoolOptions": {
-          "certificateSha1": "e33d961d35fb3161f7db607342868bb51ae05de3",
-          "signingHashAlgorithms": [
-            "sha256"
-          ],
-          "rfc3161TimeStampServer": "http://ts.ssl.com"
-        },
+      "signtoolOptions": {
+        "certificateSha1": "e33d961d35fb3161f7db607342868bb51ae05de3",
+        "signingHashAlgorithms": [
+          "sha256"
+        ],
+        "rfc3161TimeStampServer": "http://ts.ssl.com"
+      },
       "asar": "true",
       "extraResources": {
         "from": "archives",
@@ -200,6 +200,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^16.0.0",
     "eslint-plugin-promise": "^6.1.1",
+    "playwright": "^1.59.1",
     "rollup": "^4.59.0",
     "rollup-plugin-copy": "^3.4.0",
     "vite": "^6.4.2"

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     ]
   },
   "scripts": {
+    "test:electron": "node test-electron.cjs",
     "serve": "vite",
     "preview": "del-cli dist && npm run build-src && vite preview",
     "prebuild": "del-cli dist",

--- a/preload.cjs
+++ b/preload.cjs
@@ -65,6 +65,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getExternalAccessState: function () {
         return ipcRenderer.invoke('get-external-access-state');
     },
+    getArchivesPath: function () {
+        return ipcRenderer.invoke('get-archives-path');
+    },
+    downloadToArchives: function (archiveName, archiveUrl) {
+        return ipcRenderer.invoke('download-to-archives', archiveName, archiveUrl);
+    },
+    cancelDownloadToArchives: function (archiveName) {
+        return ipcRenderer.invoke('cancel-download-to-archives', archiveName);
+    },
+    onDownloadProgress: function (callback) {
+        ipcRenderer.on('download-to-archives-progress', function (_, data) {
+            callback(data);
+        });
+    },
     isMicrosoftStoreApp: process.windowsStore && regexpInstalledFromMicrosoftStore.test(__dirname),
     isAppxOrMSIX: isAppxOrMSIX(),
     __dirname: __dirname,

--- a/test-electron.cjs
+++ b/test-electron.cjs
@@ -1,0 +1,55 @@
+const { _electron: electron } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+
+(async () => {
+  console.log('Launching Electron app with Playwright...');
+  const electronApp = await electron.launch({
+    args: ['.'],
+    cwd: __dirname
+  });
+
+  const window = await electronApp.firstWindow();
+  await window.waitForLoadState('networkidle');
+  console.log('App loaded. Invoking downloadToArchives via IPC bridge...');
+
+  // Download a small test zim file (~2.9MB)
+  const archiveName = 'alpinelinux_en_all_maxi_2026-04.zim';
+  const archiveUrl = 'https://download.kiwix.org/zim/other/alpinelinux_en_all_maxi_2026-04.zim';
+
+  // Listen to console logs from the renderer to see progress
+  window.on('console', msg => console.log('Renderer:', msg.text()));
+
+  // Setup progress listener
+  await window.evaluate(() => {
+    window.electronAPI.onDownloadProgress((data) => {
+      console.log(`Progress: ${data.receivedBytes} / ${data.totalBytes}`);
+    });
+  });
+
+  console.log('Starting download...');
+  const result = await window.evaluate(async ([name, url]) => {
+    return await window.electronAPI.downloadToArchives(name, url);
+  }, [archiveName, archiveUrl]);
+
+  console.log('Download IPC returned:', result);
+
+  if (result && result.success) {
+    const filePath = result.filePath;
+    console.log(`Checking if file exists at ${filePath}...`);
+    if (fs.existsSync(filePath)) {
+      console.log('✅ Success! File was downloaded successfully.');
+      // Cleanup test file
+      fs.unlinkSync(filePath);
+      console.log('Test file cleaned up.');
+    } else {
+      console.error('❌ Failed! IPC returned success but file not found.');
+      process.exitCode = 1;
+    }
+  } else {
+    console.error('❌ Failed! IPC did not return success.');
+    process.exitCode = 1;
+  }
+
+  await electronApp.close();
+})();

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * kiwixServe.js: Provides an AJAX request process for contacting the Kiwix Download Server
  * and manipulating the returned data for display in-app
  * Also provides an object literal (langCodes) for looking up the English-language names of
@@ -566,9 +566,12 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
                 'and transfer ALL of the files there to an accessible folder on your device. After that, you can search for the folder in this app (see above).</p>\r\n';
         }
         var mirrorZimUrl = URL.replace(/\.meta4$/i, '').replace(/\/download\./, '/mirror.download.');
-        if (params.useOPFS || (window.showSaveFilePicker && params.pickedFolder && params.pickedFolder.kind === 'directory')) {
+        var isElectronApp = /Electron/.test(params.appType) && window.electronAPI && window.electronAPI.downloadToArchives;
+        if (params.useOPFS || (window.showSaveFilePicker && params.pickedFolder && params.pickedFolder.kind === 'directory') || isElectronApp) {
             bodyDoc += '<p><b>Direct download';
-            bodyDoc += params.useOPFS ? ' to Origin Private File System' : ' to your ZIM folder';
+            bodyDoc += params.useOPFS ? ' to Origin Private File System'
+                : isElectronApp ? ' to app\'s archives folder'
+                : ' to your ZIM folder';
             bodyDoc += ', for smaller archives:</b> (<i>downloads archive in-app</i>)</p><ul>\r\n<li>' +
                 '<a href="' + mirrorZimUrl + '" class="download" style="background-color: green; color: white; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download now</a> ' +
                 '<a href="' + mirrorZimUrl + '" class="download">' + mirrorZimUrl + '</a></li></ul>\r\n';
@@ -603,12 +606,74 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
             domain = domain.replace(/download/, 'library');
             return domain + file;
         });
-        // If File System Access API is available, add event listeners on download links to save to local storage
-        if (params.useOPFS || window.showSaveFilePicker) {
+        // If File System Access API or Electron API is available, add event listeners on download links to save to local storage
+        if (params.useOPFS || window.showSaveFilePicker || isElectronApp) {
             var downloadUrls = document.getElementsByClassName('download');
             for (var j = 0; j < downloadUrls.length; j++) {
                 downloadUrls[j].addEventListener('click', function (e) {
                     e.preventDefault();
+                    // For Electron apps, use the IPC-based download handler
+                    if (isElectronApp) {
+                        if (downloadSize > 0) return; // Already downloading
+                        var archiveUrl = mirrorZimUrl;
+                        var archiveName = e.target.href.replace(/^.*\/([^/]+)$/, '$1');
+                        var downloadArchiveElectron = function () {
+                            downloadSize = megabytes;
+                            uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Downloading archive... 0%', true);
+                            // Set up progress listener (only once)
+                            if (!window._electronDownloadProgressListenerSet) {
+                                window._electronDownloadProgressListenerSet = true;
+                                electronAPI.onDownloadProgress(function (data) {
+                                    reportDownloadProgress(data.receivedBytes, data.totalBytes);
+                                });
+                            }
+                            electronAPI.downloadToArchives(archiveName, archiveUrl).then(function (result) {
+                                if (result && result.success) {
+                                    reportDownloadProgress('completed');
+                                    uiUtil.systemAlert('<p>The archive <b>' + archiveName + '</b> has been downloaded to the app\'s archives folder.</p>' +
+                                        '<p><b>Reloading archive list...</b></p>', 'Download complete').then(function () {
+                                        // Refresh the archive list to include the newly downloaded file
+                                        settingsStore.setItem('lastSelectedArchive', archiveName, Infinity);
+                                        // Re-scan the archives folder and load the new archive
+                                        var archivesDir = electronAPI.__dirname.replace(/[/\\]app\.asar/, '') + '/archives';
+                                        settingsStore.removeItem('listOfArchives');
+                                        downloadSize = 0;
+                                        percentageComplete = 0;
+                                        // Use loadPackagedArchive or scanNodeFolderforArchives to refresh
+                                        if (typeof scanNodeFolderforArchives === 'function') {
+                                            scanNodeFolderforArchives(archivesDir, function () {
+                                                setLocalArchiveFromArchiveList(archiveName);
+                                            });
+                                        } else if (typeof loadPackagedArchive === 'function') {
+                                            loadPackagedArchive();
+                                        } else {
+                                            window.location.reload();
+                                        }
+                                    });
+                                }
+                            }).catch(function (err) {
+                                uiUtil.pollOpsPanel();
+                                console.error('Download error:', err);
+                                downloadSize = 0;
+                                percentageComplete = 0;
+                                uiUtil.systemAlert('<p>Unable to download the archive <b>' + archiveName + '</b> to the archives folder.</p>' +
+                                    '<p>Error: ' + (err.message || err) + '</p>' +
+                                    '<p>You can try using a browser-managed download link instead.</p>', 'Download failed');
+                            });
+                        };
+                        if (megabytes > 1000) {
+                            var message = '<p>Do you wish to download the following <b>large</b> archive to the app\'s archives folder' +
+                                '?</p><ul><li><i>' + archiveName + '</i> (<b>' + megabytes$ + ' MB</b>)</li></ul><p><b><i>If you proceed, do not close the app during the download.</i></b><p>' +
+                                '<p>If you prefer to download in the background, use a browser-managed download link instead.</p>';
+                            uiUtil.systemAlert(message, 'Download large archive to archives folder?', true, 'Cancel', 'Download').then(function (result) {
+                                if (result) downloadArchiveElectron();
+                            });
+                        } else {
+                            downloadArchiveElectron();
+                        }
+                        return;
+                    }
+                    // Non-Electron flow (OPFS / File System Access API)
                     if (!(params.pickedFolder && params.pickedFolder.kind === 'directory') || downloadSize > 0) return;
                     if (params.useOPFS) {
                         var quotaInMB = appstate.OPFSQuota / (1024 * 1024);

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1170,11 +1170,11 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
                 'and transfer ALL of the files there to an accessible folder on your device. After that, you can search for the folder in this app (see above).</p>\r\n';
         }
         var mirrorZimUrl = URL.replace(/\.meta4$/i, '').replace(/\/download\./, '/mirror.download.');
-        var isElectronApp = /Electron/.test(params.appType) && window.electronAPI && window.electronAPI.downloadToArchives;
-        if (params.useOPFS || (window.showSaveFilePicker && params.pickedFolder && params.pickedFolder.kind === 'directory') || isElectronApp) {
+        var isPackagedElectronApp = /Electron/.test(params.appType) && window.electronAPI && window.electronAPI.downloadToArchives && !!params.packagedFile;
+        if (params.useOPFS || (window.showSaveFilePicker && params.pickedFolder && params.pickedFolder.kind === 'directory') || isPackagedElectronApp) {
             bodyDoc += '<p><b>Direct download';
             bodyDoc += params.useOPFS ? ' to Origin Private File System'
-                : isElectronApp ? ' to app\'s archives folder'
+                : isPackagedElectronApp ? ' to app\'s archives folder'
                 : ' to your ZIM folder';
             bodyDoc += ', for smaller archives:</b> (<i>downloads archive in-app</i>)</p><ul>\r\n<li>' +
                 '<a href="' + mirrorZimUrl + '" class="download" style="background-color: green; color: white; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download now</a> ' +
@@ -1211,13 +1211,13 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
             return domain + file;
         });
         // If File System Access API or Electron API is available, add event listeners on download links to save to local storage
-        if (params.useOPFS || window.showSaveFilePicker || isElectronApp) {
+        if (params.useOPFS || window.showSaveFilePicker || isPackagedElectronApp) {
             var downloadUrls = document.getElementsByClassName('download');
             for (var j = 0; j < downloadUrls.length; j++) {
                 downloadUrls[j].addEventListener('click', function (e) {
                     e.preventDefault();
                     // For Electron apps, use the IPC-based download handler
-                    if (isElectronApp) {
+                    if (isPackagedElectronApp) {
                         if (downloadSize > 0) return; // Already downloading
                         var archiveUrl = mirrorZimUrl;
                         var archiveName = e.target.href.replace(/^.*\/([^/]+)$/, '$1');


### PR DESCRIPTION

Fixes #818

Currently, Electron packaged apps (Wikivoyage, WikiMed) don't expose the internal archive location for direct download of archives in other languages. Users must click on a mirror link, save the archive via the browser's Save As dialog, and then manually pick the file again in the app — a cumbersome process.

This PR adds a **"Direct download to app's archives folder"** option in the download panel for Electron apps. When clicked, the archive is downloaded directly into the app's internal `archives/` directory via IPC, with real-time progress tracking. After download, the app automatically reloads and picks up the new archive.

## Changes

### Backend (`main.cjs`)
- **`download-to-archives` IPC handler**: Downloads a ZIM archive from a given URL directly into the app's archives folder. Features:
  - HTTP/HTTPS support with automatic redirect following (3xx)
  - Atomic writes using a `.download` temp file, renamed to final name on completion
  - Progress reporting every ~512KB via IPC to the renderer
  - Active download tracking via a `Map` to support cancellation
- **`cancel-download-to-archives` IPC handler**: Aborts an in-progress download and cleans up the temp file
- **`get-archives-path` IPC handler**: Returns the archives directory path (handles both development and production/asar-packed modes)

### Preload (`preload.cjs`)
- Exposed four new APIs via `contextBridge.exposeInMainWorld`:
  - `downloadToArchives(archiveName, archiveUrl)` — triggers the download
  - `cancelDownloadToArchives(archiveName)` — cancels an active download
  - `onDownloadProgress(callback)` — subscribes to progress events
  - `getArchivesPath()` — returns the archives directory path

### Frontend (`www/js/lib/kiwixServe.js`)
- Detects Electron environment and shows a green **"Download now"** button labeled **"Direct download to app's archives folder"**
- On click, initiates the IPC download with:
  - Real-time progress bar in the ops panel (percentage + MB downloaded)
  - Confirmation dialog for large archives (>1GB) warning users not to close the app
  - Error handling with user-friendly messages and fallback to browser-managed download
  - Post-download: stores the archive name, shows success dialog, and reloads to activate the new archive

### Test (`test-electron.cjs`) — New file
- Playwright-based integration test that:
  - Launches the Electron app
  - Invokes the `downloadToArchives` IPC with a small test ZIM (~2.9MB)
  - Verifies progress events are received
  - Confirms the file is saved to the correct path
  - Cleans up the test file

## Testing

### Automated
```
$ node test-electron.cjs
Launching Electron app with Playwright...
App loaded. Invoking downloadToArchives via IPC bridge...
Starting download...
Progress: 540KB / 3MB → 1MB → 1.5MB → 2.1MB → 2.6MB
Download IPC returned: { success: true, filePath: '.../archives/alpinelinux_en_all_maxi_2026-04.zim' }
✅ Success! File was downloaded successfully.
Test file cleaned up.
Exit code: 0
```

### Manual
1. Launch the Electron app
2. Go to Configuration → Download archives
3. Browse to any archive category and select a `.zim` file
4. The meta4 link page now shows "Direct download to app's archives folder" with a green "Download now" button
5. Click the button → progress is shown in the ops panel
6. On completion, a success dialog appears and the app reloads with the new archive available

