### PR TITLE
Add web torrent for Electron packages

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -881,7 +881,7 @@ jobs:
                     if (!$INPUT_SIGN) {
                         npx electron-builder build --config ../scripts/electronBuilder.cjs --win nsis-web --ia32 --x64 --arm64 --publish always --projectDir dist
                     } else {
-                        npx electron-builder build --win nsis-web --ia32 --x64 --arm64 --publish always --projectDir dist
+                        npx electron-builder build --config ../scripts/electronBuilder-signed.cjs --win nsis-web --ia32 --x64 --arm64 --publish always --projectDir dist
                     }
                 }
                 'appx' {
@@ -899,7 +899,7 @@ jobs:
                     } else {
                         npx electron-builder build --win $PHASE1_TARGETS --publish always --projectDir dist
                         node scripts/delete-latest-yml.js
-                        npx electron-builder build --win nsis-web --ia32 --x64 --arm64 --publish always --projectDir dist
+                        npx electron-builder build --config ../scripts/electronBuilder-signed.cjs --win nsis-web --ia32 --x64 --arm64 --publish always --projectDir dist
                     }
                 }
             }
@@ -910,7 +910,7 @@ jobs:
                     if (!$INPUT_SIGN) {
                         npx electron-builder build --config ../scripts/electronBuilder.cjs --win nsis-web --ia32 --x64 --arm64 --projectDir dist
                     } else {
-                        npx electron-builder build --win nsis-web --ia32 --x64 --arm64 --projectDir dist
+                        npx electron-builder build --config ../scripts/electronBuilder-signed.cjs --win nsis-web --ia32 --x64 --arm64 --projectDir dist
                     }
                 }
                 'appx' {
@@ -928,7 +928,7 @@ jobs:
                     } else {
                         npx electron-builder build --win $PHASE1_TARGETS --projectDir dist
                         node scripts/delete-latest-yml.js
-                        npx electron-builder build --win nsis-web --ia32 --x64 --arm64 --projectDir dist
+                        npx electron-builder build --config ../scripts/electronBuilder-signed.cjs --win nsis-web --ia32 --x64 --arm64 --projectDir dist
                     }
                 }
             }

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -180,11 +180,23 @@ jobs:
           PUBLISH_FLAG="always"
         fi
         echo "Building 64bit packages for ref_name=$REF_NAME..."
+        # Build the x64 targets first, using the runner's native linux-x64 node-datachannel binary.
+        # electron-builder has npmRebuild:false, so it packages whatever single binary is on disk
+        # into every arch it builds — building arm64 in the same pass would ship the x64 binary in
+        # the arm64 AppImage (dlopen would fail on ARM). So after the x64 targets, swap in the
+        # linux-arm64 prebuild (a plain N-API download via prebuild-install, no compilation) and
+        # build the arm64 AppImage separately. The node -e form invokes prebuild-install from the
+        # package dir so it reads node-datachannel's own package.json, hoisting-agnostic.
         if [[ $REF_NAME = "main" ]]; then
-          npx electron-builder --linux AppImage:x64 AppImage:arm64 deb:x64 rpm:x64 --publish $PUBLISH_FLAG --projectDir dist
+          npx electron-builder --linux AppImage:x64 deb:x64 rpm:x64 --publish $PUBLISH_FLAG --projectDir dist
         else
-          npx electron-builder --linux AppImage:x64 AppImage:arm64 deb:x64 --publish $PUBLISH_FLAG --projectDir dist
+          npx electron-builder --linux AppImage:x64 deb:x64 --publish $PUBLISH_FLAG --projectDir dist
         fi
+        echo "Swapping node-datachannel to its linux-arm64 prebuild for the ARM AppImage..."
+        ( cd dist/node_modules/node-datachannel && node -e "process.argv.push('-r','napi','--arch=arm64','--platform=linux'); require('prebuild-install/bin.js')" )
+        file dist/node_modules/node-datachannel/build/Release/node_datachannel.node
+        echo "Building arm64 AppImage (with the linux-arm64 binary swapped in)..."
+        npx electron-builder --linux AppImage:arm64 --publish $PUBLISH_FLAG --projectDir dist
     - name: Build and publish 32bit
       env:
         USE_HARD_LINKS: false

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -866,7 +866,10 @@ jobs:
         $phase1Targets = @()
         if ($packageName -notmatch 'wikimed') { $phase1Targets += 'NSIS:ia32' }
         if ($packageName -notmatch 'wikimed|wikivoyage') { $phase1Targets += 'portable:ia32' }
-        $phase1Targets += 'appx'
+        # Pin appx to x64: in a combined --win list electron-builder applies the archs collected from
+        # the other targets (here ia32) to any bare target, and appx has no ia32 build, so a bare
+        # 'appx' aborts phase 1 with "Unsupported arch ia32 appx". An explicit arch avoids that.
+        $phase1Targets += 'appx:x64'
         $PHASE1_TARGETS = $phase1Targets -join ' '
         echo "Phase 1 build targets: $PHASE1_TARGETS"
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -329,6 +329,13 @@ jobs:
         echo "Copying the package.json to dist"
         cp ./package.json ./dist/package.json
         cp ./package-lock.json ./dist/package-lock.json
+        # Strip webtorrent: unusable on this legacy target (Electron 26 = Node 18, below
+        # WebTorrent's Node 20 requirement), so it would only ship as dead weight (~9 MB of
+        # webtorrent + node-datachannel). The in-app torrent feature is already gated off for
+        # this runtime (see preload.cjs), so removing it changes nothing user-facing. Only the
+        # dist copy is stripped; the modern build step later restores the full package.json.
+        echo "Removing webtorrent from dist before install (unsupported on legacy macOS / Node 18)"
+        node -e "var fs=require('fs'),p=JSON.parse(fs.readFileSync('./dist/package.json')); if (p.dependencies) delete p.dependencies.webtorrent; fs.writeFileSync('./dist/package.json', JSON.stringify(p, null, 2));"
         echo "Removing old Electron and installing exactly 26.6.10 in root and dist"
         npm uninstall electron && npm install electron@26.6.10 --save-exact --save-dev
         cd dist && npm install electron@26.6.10 --save-exact --save-dev && cd ..

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -193,6 +193,11 @@ jobs:
       run: |
         echo "Changing Electron version to latest that supports 32bit Linux (18.3.15) in ./dist/package.json"
         sed -i -E 's/("electron":\s")[^"]+/\118.3.15/' ./dist/package.json
+        # Strip webtorrent: unusable on this target (Electron 18 = Node 16, below WebTorrent's Node
+        # 20 requirement, and node-datachannel has no ia32 prebuild), so it would only ship as dead
+        # weight. The in-app torrent feature is already gated off for this runtime (see preload.cjs).
+        echo "Removing webtorrent from dist before install (unsupported on 32-bit / Node 16)"
+        node -e "var fs=require('fs'),p=JSON.parse(fs.readFileSync('./dist/package.json')); if (p.dependencies) delete p.dependencies.webtorrent; fs.writeFileSync('./dist/package.json', JSON.stringify(p, null, 2));"
         echo "Installing dependencies in dist"
         cd dist && npm install && cd ..
         # For GitHub, use onTagOrDraft so packages publish to an existing draft release;
@@ -698,6 +703,11 @@ jobs:
         echo "Copying the package.json to dist"
         cp ./package.json ./dist/package.json
         cp ./package-lock.json ./dist/package-lock.json
+        # Strip webtorrent: unusable on this target (Electron 22 = Node 16, below WebTorrent's Node
+        # 20 requirement, and node-datachannel has no ia32 prebuild), so it would only ship as dead
+        # weight. The in-app torrent feature is already gated off for this runtime (see preload.cjs).
+        echo "Removing webtorrent from dist before install (unsupported on Win7 32-bit / Node 16)"
+        node -e "var fs=require('fs'),p=JSON.parse(fs.readFileSync('./dist/package.json')); if (p.dependencies) delete p.dependencies.webtorrent; fs.writeFileSync('./dist/package.json', JSON.stringify(p, null, 2));"
         echo "Installing dependencies in root and dist"
         npm install; cd dist; npm install; cd ..
         echo "Installed Electron version:$(npx electron --version)"

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -385,7 +385,21 @@ jobs:
           echo "✓ Electron versions verified successfully"
         fi
         echo "Building modern macOS packages for ref_name=$REF_NAME..."
-        npx electron-builder --mac zip:x64 zip:arm64 --publish never --projectDir dist
+        # The arm64 macos-latest runner's npm install placed a darwin-arm64 node-datachannel
+        # binary in dist. electron-builder has npmRebuild:false, so it packages whatever single
+        # binary is on disk into EVERY arch it builds — a combined "zip:x64 zip:arm64" would ship
+        # the arm64 binary inside the Intel package too (dlopen fails: "incompatible architecture,
+        # have 'arm64', need 'x86_64'"). So build arm64 from the native binary, then swap in the
+        # darwin-x64 prebuild (a plain N-API download via prebuild-install, no compilation) and
+        # build x64 separately. The node -e form invokes prebuild-install from the package dir so
+        # it reads node-datachannel's own package.json, and resolves regardless of npm hoisting.
+        echo "Building macOS arm64 (native node-datachannel binary already in place)..."
+        npx electron-builder --mac zip:arm64 --publish never --projectDir dist
+        echo "Swapping node-datachannel to its darwin-x64 prebuild for the Intel build..."
+        ( cd dist/node_modules/node-datachannel && node -e "process.argv.push('-r','napi','--arch=x64','--platform=darwin'); require('prebuild-install/bin.js')" )
+        file dist/node_modules/node-datachannel/build/Release/node_datachannel.node
+        echo "Building macOS x64 (with the darwin-x64 binary swapped in)..."
+        npx electron-builder --mac zip:x64 --publish never --projectDir dist
         echo "Renaming modern macOS packages to avoid conflicts..."
         cd dist/bld/Electron
         for file in *.zip; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* ENHANCEMENT: In-app BitTorrent download of ZIM archives in the Electron app (with WebTorrent), including resume of interrupted downloads and optional seeding until app close
+
 ## Release 3.8.5 / 3.8.6
 
 * ENHANCEMENT: Support native auto dark/light theming system in new Wikimedia ZIMs (SW mode only)

--- a/main.cjs
+++ b/main.cjs
@@ -7,6 +7,8 @@ const { autoUpdater } = require('electron-updater');
 const contextMenu = require('electron-context-menu');
 const fs = require('fs');
 const os = require('os');
+// In-app BitTorrent downloader (lazily imports WebTorrent on first use)
+const torrentDownloader = require('./torrentDownloader.cjs');
 // const https = require('https');
 
 const store = new Store();
@@ -194,6 +196,36 @@ function registerListeners () {
         const localIP = isExternal ? getLocalIPAddress() : null;
         console.log(`Get external access state: ${isExternal} (binding: ${currentBinding})`);
         return { enabled: isExternal, binding: currentBinding, localIP: localIP };
+    });
+    // In-app BitTorrent download handlers: these wrap torrentDownloader.cjs, relaying progress
+    // and completion events to the renderer over IPC
+    const sendToRenderer = function (channel, data) {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send(channel, data);
+        }
+    };
+    ipcMain.handle('torrent-start', async (event, args) => {
+        try {
+            const status = await torrentDownloader.startDownload(args, {
+                onProgress: (s) => sendToRenderer('torrent-progress', s),
+                onDone: (s) => sendToRenderer('torrent-done', s),
+                onError: (err) => sendToRenderer('torrent-error', err.message)
+            });
+            return { ok: true, status: status };
+        } catch (err) {
+            console.error('Torrent start failed:', err);
+            return { ok: false, error: err.message };
+        }
+    });
+    ipcMain.handle('torrent-stop', async (event, infoHash, deletePartial) => {
+        return torrentDownloader.stopTorrent(infoHash, deletePartial);
+    });
+    ipcMain.handle('torrent-status', (event, infoHash) => {
+        return torrentDownloader.getStatus(infoHash);
+    });
+    ipcMain.on('torrent-set-seeding', (event, value) => {
+        console.log('Setting torrent seeding to ' + value);
+        torrentDownloader.setKeepSeeding(value);
     });
     // Registers listener for download events
     mainWindow.webContents.session.on('will-download', (event, item, webContents) => {
@@ -449,6 +481,8 @@ app.on('window-all-closed', function () {
 
 // Explicit shutdown of the Express server for security
 app.on('before-quit', () => {
+    // Stop any active or seeding torrents (partial downloads are kept on disk for later resume)
+    torrentDownloader.destroyAll();
     if (expressServer) {
         console.log('Shutting down server...');
         // Forcefully close all active connections

--- a/main.cjs
+++ b/main.cjs
@@ -231,6 +231,14 @@ function registerListeners () {
         console.log('Setting torrent seeding to ' + value);
         torrentDownloader.setKeepSeeding(value);
     });
+    ipcMain.handle('torrent-delete-partial', async (event, savePath, name) => {
+        try {
+            return { ok: true, deleted: await torrentDownloader.deletePartialFile(savePath, name) };
+        } catch (err) {
+            console.error('Torrent partial-file delete failed:', err);
+            return { ok: false, error: err.message };
+        }
+    });
     // Registers listener for download events
     mainWindow.webContents.session.on('will-download', (event, item, webContents) => {
         // Set the save path, making Electron not to prompt a save dialog.

--- a/main.cjs
+++ b/main.cjs
@@ -205,12 +205,16 @@ function registerListeners () {
         }
     };
     ipcMain.handle('torrent-start', async (event, args) => {
+        // The infoHash of this download, once known: it lets the renderer route the error
+        // event to the right torrent (progress and done statuses carry their own infoHash)
+        let infoHash = null;
         try {
             const status = await torrentDownloader.startDownload(args, {
                 onProgress: (s) => sendToRenderer('torrent-progress', s),
                 onDone: (s) => sendToRenderer('torrent-done', s),
-                onError: (err) => sendToRenderer('torrent-error', err.message)
+                onError: (err) => sendToRenderer('torrent-error', { infoHash: infoHash, message: err.message })
             });
+            infoHash = status.infoHash;
             return { ok: true, status: status };
         } catch (err) {
             console.error('Torrent start failed:', err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "electron-context-menu": "^3.1.1",
         "electron-store": "^8.1.0",
         "electron-updater": "^6.6.8",
-        "express": "^4.22.2"
+        "express": "^4.22.2",
+        "webtorrent": "3.0.16"
       },
       "devDependencies": {
         "@babel/cli": "^7.21.5",
@@ -3241,6 +3242,23 @@
         "win32"
       ]
     },
+    "node_modules/@silentbot1/nat-api": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@silentbot1/nat-api/-/nat-api-0.4.9.tgz",
+      "integrity": "sha512-Bm2Fr0sJyGr4B/XgKjQxjGe7Rzs/OlK91OIHsghObxhP3Y4j2y8o7Xjlledu/pxzFEIWaTbZIBSl8ABqoP/WhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chrome-dgram": "^3.0.6",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "debug": "^4.4.0",
+        "default-gateway": "^7.2.2",
+        "unordered-array-remove": "^1.0.2",
+        "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -3265,6 +3283,50 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@thaunknown/simple-peer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@thaunknown/simple-peer/-/simple-peer-10.1.1.tgz",
+      "integrity": "sha512-cQHGk4J7eXL9zmGELnFrB9YszZBZGE6T06OH/iCAN6H/ObckK84pyddTlVU45PEkeVKyICzJbhPgeL9xwF64Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "err-code": "^3.0.1",
+        "streamx": "^2.25.0",
+        "uint8-util": "^2.2.6",
+        "webrtc-polyfill": "^1.2.1"
+      }
+    },
+    "node_modules/@thaunknown/simple-peer/node_modules/err-code": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+      "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
+      "license": "MIT"
+    },
+    "node_modules/@thaunknown/simple-websocket": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@thaunknown/simple-websocket/-/simple-websocket-9.1.4.tgz",
+      "integrity": "sha512-NgEFe6TFqRaQvRJF7kFTg0qz7Z28lNiTmAgIY0voNMxrrZtasZKFR3KtN6MtYeS8fOLzn7RLLKQgpV0b8dvCng==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "queue-microtask": "^1.2.3",
+        "streamx": "^2.25.0",
+        "uint8-util": "^2.2.6",
+        "ws": "^8.20.1"
+      }
+    },
+    "node_modules/@thaunknown/thirty-two": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@thaunknown/thirty-two/-/thirty-two-1.0.5.tgz",
+      "integrity": "sha512-Q53KyCXweV1CS62EfqtPDqfpksn5keQ59PGqzzkK+g8Vif1jB4inoBCcs/BUSdsqddhE3G+2Fn+4RX3S6RqT0A==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8-util": "^2.2.5"
+      },
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -3397,6 +3459,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@webtorrent/http-node": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@webtorrent/http-node/-/http-node-1.3.0.tgz",
+      "integrity": "sha512-GWZQKroPES4z91Ijx6zsOsb7+USOxjy66s8AoTWg0HiBBdfnbtf9aeh3Uav0MgYn4BL8Q7tVSUpd0gGpngKGEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "freelist": "^1.0.3",
+        "http-parser-js": "^0.4.3"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -3415,6 +3487,18 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -3448,6 +3532,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/addr-to-ip-port": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-2.0.0.tgz",
+      "integrity": "sha512-9bYbtjamtdLHZSqVIUXhilOryNPiL+x+Q5J/Unpg4VY3ZIkK3fT52UoErj1NdUeVm3J1t2iBEAur4Ywbl/bahw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/agent-base": {
@@ -4004,6 +4097,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
@@ -4085,11 +4192,143 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4106,6 +4345,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bencode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-4.0.1.tgz",
+      "integrity": "sha512-/bCR3FvgfB8AZk4LlowShU+nfaTNRM2vruJ9aejDa5LpgkCoRjFyEauFiZFxbpxVxQbBFapYCN42Er2dkE/Qgw==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8-util": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bep53-range": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bep53-range/-/bep53-range-2.0.1.tgz",
+      "integrity": "sha512-VWN7j7sqUssWD6ROZe2m709YL3u5A1IAx1qvAbH3DAhszHt4WPvCzJLRJ+mzmZn1qWIb4mpflwdn95qezz3n8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4115,6 +4375,229 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bitfield": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bitfield/-/bitfield-5.0.1.tgz",
+      "integrity": "sha512-81mvFHCa0L1HsDdKVCTkPKZZ6KFdyXgfQNoneFT7Qk5/PZeBWdPkTFa4KttbR8uHszfjiqOJbeahLOPfCqw4cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/bittorrent-dht": {
+      "version": "11.0.12",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-11.0.12.tgz",
+      "integrity": "sha512-bFmQq874HMIBon/6KNMf/U1OG+UxJ0UzI9oPra2IRlZLuPA7VwBiA7uEpWaO2ww8G76OFjxB1p1XCOS94FuCPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^4.0.1",
+        "debug": "^4.4.3",
+        "k-bucket": "^5.1.0",
+        "k-rpc": "^5.1.0",
+        "last-one-wins": "^1.0.4",
+        "lru": "^3.1.0",
+        "randombytes": "^2.1.0",
+        "record-cache": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bittorrent-lsd": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bittorrent-lsd/-/bittorrent-lsd-2.0.3.tgz",
+      "integrity": "sha512-FE4ImhpJZo8ahzDS/Qk1Ol+3Ea1sIhCPWE2WSjiv1s8YoCSEf7JBL3bbCJW5hdVNK5ohtZ3vH5xGjZ9QWFiatQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "chrome-dgram": "^3.0.6",
+        "debug": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bittorrent-peerid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bittorrent-peerid/-/bittorrent-peerid-2.0.2.tgz",
+      "integrity": "sha512-V2iUvbtv31uLA8XFxbhB3f/fKTxWGaa6FI/3wSm93YAS/DS8IkeRWCyYGQ13Xbc9ajR40nsxNjGtVt7OHB3VOQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bittorrent-protocol": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-5.0.6.tgz",
+      "integrity": "sha512-qI0PeZpMBQyhvMGvsw0aJjUSMJwMNc6lLzD1TX3Q1MmzA3s3fNZrk/PKHpzrjyR9xNGBZeQ5ZuT3Stym6AUq+Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^4.0.1",
+        "bitfield": "^5.0.1",
+        "debug": "^4.4.3",
+        "streamx": "^2.26.0",
+        "throughput": "^1.0.2",
+        "uint8-util": "^2.2.6",
+        "unordered-array-remove": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/bittorrent-protocol/node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/bittorrent-tracker": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-11.2.3.tgz",
+      "integrity": "sha512-i9pWOf1YAQWyTjDnpWwcTfEYDi5XwqD6f48pKmIHByb7x2XU86CqK+IsyMy1buKkDZ3rDKht2jIeKCZf1Dmd8g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@thaunknown/simple-peer": "^10.0.8",
+        "@thaunknown/simple-websocket": "^9.1.3",
+        "bencode": "^4.0.0",
+        "bittorrent-peerid": "^2.0.0",
+        "chrome-dgram": "^3.0.6",
+        "compact2string": "^1.4.1",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "debug": "^4.3.4",
+        "ip": "^2.0.1",
+        "lru": "^3.1.0",
+        "minimist": "^1.2.8",
+        "once": "^1.4.0",
+        "queue-microtask": "^1.2.3",
+        "random-iterate": "^1.0.1",
+        "run-parallel": "^1.2.0",
+        "run-series": "^1.1.9",
+        "socks": "^2.8.3",
+        "string2compact": "^2.0.1",
+        "uint8-util": "^2.2.5",
+        "unordered-array-remove": "^1.0.2",
+        "ws": "^8.17.0"
+      },
+      "bin": {
+        "bittorrent-tracker": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.8",
+        "utf-8-validate": "^6.0.4"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/block-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/block-iterator/-/block-iterator-1.1.2.tgz",
+      "integrity": "sha512-yAHUP44v2K25xLPdrgVTgwtuQctlullzjczu9CoUZom5AP3g4p1R1+aWHjS1GHG9JtcSUVUnbEPiuXiW5YZ24w==",
+      "license": "MIT"
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -4284,11 +4767,49 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/builder-util": {
       "version": "26.15.3",
@@ -4420,6 +4941,30 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/cache-chunk-store": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/cache-chunk-store/-/cache-chunk-store-3.2.2.tgz",
+      "integrity": "sha512-2lJdWbgHFFxcSth9s2wpId3CR3v1YC63KjP4T9WhpW7LWlY7Hiiei3QwwqzkWqlJTfR8lSy9F5kRQECeyj+yQA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lru": "^3.1.0",
+        "queue-microtask": "^1.2.3"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -4625,12 +5170,77 @@
         "node": ">=18"
       }
     },
+    "node_modules/chrome-dgram": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.6.tgz",
+      "integrity": "sha512-bqBsUuaOiXiqxXt/zA/jukNJJ4oaOtc7ciwqJpZVEaaXwwxqgI2/ZdG02vXYWUhHGziDlvGMQWk0qObgJwVYKA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "run-series": "^1.1.9"
+      }
+    },
+    "node_modules/chrome-dns": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
+      "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
+      "license": "MIT",
+      "dependencies": {
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/chrome-net": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.4.tgz",
+      "integrity": "sha512-Jzy2EnzmE+ligqIZUsmWnck9RBXLuUy6CaKyuNMtowFG3ZvLt8d+WBJCTPEludV0DHpIKjAOlwjFmTaEdfdWCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
+    },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chunk-store-iterator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chunk-store-iterator/-/chunk-store-iterator-1.0.4.tgz",
+      "integrity": "sha512-LGjzJNmk7W1mrdaBoJNztPumT2ACmgjHmI1AMm8aeGYOl4+LKaYC/yfnx27i++LiAtoe/dR+3jC8HRzb6gW4/A==",
+      "license": "MIT",
+      "dependencies": {
+        "block-iterator": "^1.1.1"
+      }
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -4768,6 +5378,15 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
+    },
+    "node_modules/compact2string": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/compact2string/-/compact2string-1.4.1.tgz",
+      "integrity": "sha512-3D+EY5nsRhqnOwDxveBv5T8wGo4DEvYxjDtPGmdOX+gfr5gE92c2RC0w2wa+xEefm07QuVqqcF3nZJUZ92l/og==",
+      "license": "BSD",
+      "dependencies": {
+        "ipaddr.js": ">= 0.1.5"
+      }
     },
     "node_modules/compare-version": {
       "version": "0.1.2",
@@ -4911,6 +5530,66 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cpus": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cpus/-/cpus-1.0.3.tgz",
+      "integrity": "sha512-PXHBvGLuL69u55IkLa5e5838fLhIMHxmkV4ge42a8alGyn7BtawYgI0hQ849EedvtHIOLNNH3i6eQU1BiE9SUA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/create-torrent": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/create-torrent/-/create-torrent-6.1.2.tgz",
+      "integrity": "sha512-PrqAy9matS8HquhCQp45SyTEgshxK21SiZt9RxFNHybTWp3lYICebjj4zENl6jpjQGzuJ8DdI92TJuV73CO4YA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^4.0.1",
+        "block-iterator": "^1.1.2",
+        "fast-readable-async-iterator": "^2.0.0",
+        "is-file": "^1.0.0",
+        "join-async-iterator": "^1.1.1",
+        "junk": "^4.0.1",
+        "minimist": "^1.2.8",
+        "once": "^1.4.0",
+        "piece-length": "^2.0.1",
+        "queue-microtask": "^1.2.3",
+        "run-parallel": "^1.2.0",
+        "uint8-util": "^2.2.6"
+      },
+      "bin": {
+        "create-torrent": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
@@ -4920,11 +5599,20 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/cross-fetch-ponyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch-ponyfill/-/cross-fetch-ponyfill-1.0.3.tgz",
+      "integrity": "sha512-uOBkDhUAGAbx/FEzNKkOfx3w57H8xReBBXoZvUnOKTI0FW0Xvrj3GrYv2iZXUqlffC1LMGfQzhmBM/ke+6eTDA==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.3.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4932,6 +5620,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debounce-fn": {
@@ -4949,11 +5646,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5014,7 +5712,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -5030,13 +5727,21 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -5052,6 +5757,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "execa": "^7.1.1"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/defer-to-connect": {
@@ -5182,7 +5899,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5720,7 +6436,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -6313,6 +7028,95 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -6406,6 +7210,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -6434,6 +7244,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-readable-async-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-readable-async-iterator/-/fast-readable-async-iterator-2.0.0.tgz",
+      "integrity": "sha512-8Sld+DuyWRIftl86ZguJxR2oXCBccOiJxrY/Rj9/7ZBynW8pYMWzIcqxFL1da+25jaWJZVa+HHX/8SsA21JdTA==",
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -6456,6 +7272,29 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -6501,6 +7340,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -6607,6 +7458,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -6615,6 +7478,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/freelist": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/freelist/-/freelist-1.0.3.tgz",
+      "integrity": "sha512-Ji7fEnMdZDGbS5oXElpRJsn9jPvBR8h/037D3bzreNmS8809cISq/2D9//JbA/TaZmkkN8cmecXwmQHmM+NHhg==",
+      "license": "MIT"
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -6622,6 +7491,43 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-chunk-store": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-5.0.1.tgz",
+      "integrity": "sha512-bhD1YfAzdOugxu4VepYjxvzZwik9Qunn69Ogj47DZmogD6h/VkD/4vArNRoQ+kPYYOFqex3c9Ob2iAOkNYdkgw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0",
+        "queue-microtask": "^1.2.2",
+        "random-access-file": "^4.0.0",
+        "run-parallel": "^1.1.2",
+        "thunky": "^1.0.1",
+        "uint8-util": "^2.2.5"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -6637,6 +7543,17 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/fs-native-extensions": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
+      "integrity": "sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.0"
+      }
+    },
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -6648,6 +7565,15 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsa-chunk-store": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fsa-chunk-store/-/fsa-chunk-store-1.3.0.tgz",
+      "integrity": "sha512-0WCfuxqqSB6Tz/g7Ar/nwAxMoigXaIXuvfrnLIEFYIA9uc6w9eNaHuBGzU1X3lyM4cpLKCOTUmKAA/gCiTvzMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -6755,6 +7681,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stdin": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-10.0.0.tgz",
+      "integrity": "sha512-eWSePJ4zXFdqz+/Lyfopob4rIcoF/U2XfE8nJc7iZV6lnebWc9k7DoQQpX+2a9jc0AOvBsXvbe5YkjXl/MHbpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -6786,6 +7724,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -7095,6 +8039,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha512-u8u5ZaG0Tr/VvHlucK2ufMuOp4/5bvwgneXle+y228K5rMbJOlVjThONcaAw3ikAy8b2OO9RfEucdMHFz3UWMA==",
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -7137,6 +8087,35 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -7144,6 +8123,29 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immediate-chunk-store": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/immediate-chunk-store/-/immediate-chunk-store-2.2.0.tgz",
+      "integrity": "sha512-1bHBna0hCa6arRXicu91IiL9RvvkbNYLVq+mzWdaLGZC3hXvX4doh8e1dLhMKez5siu63CYgO5NrGJbRX5lbPA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.3"
       }
     },
     "node_modules/import-fresh": {
@@ -7198,6 +8200,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -7210,6 +8218,34 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-set": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ip-set/-/ip-set-3.0.0.tgz",
+      "integrity": "sha512-EkKzllMFYKMHOoeNxM8v10IJM2n9K6L3ruaQx4A/5RrkOInV8cjp9IwkVU0/cpzwwkq1zGNudrAdCjSR97Rf5w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ipaddr.js": {
@@ -7343,6 +8379,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-file/-/is-file-1.0.0.tgz",
+      "integrity": "sha512-ZGMuc+xA8mRnrXtmtf2l/EkIW2zaD2LSBWlaOVEF6yH4RTndHob65V4SwWWdtGKVthQfXPVKsXqw4TDUjbVxVQ==",
+      "license": "MIT"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -7492,6 +8534,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -7576,8 +8630,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jake": {
       "version": "10.9.4",
@@ -7606,6 +8659,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/join-async-iterator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/join-async-iterator/-/join-async-iterator-1.1.1.tgz",
+      "integrity": "sha512-ATse+nuNeKZ9K1y27LKdvPe/GCe9R/u9dw9vI248e+vILeRK3IcJP4JUPAlSmKRCDK0cKhEwfmiw4Skqx7UnGQ==",
+      "license": "MIT"
     },
     "node_modules/jquery": {
       "version": "3.7.1",
@@ -7714,6 +8773,56 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/junk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/k-bucket": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
+      "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/k-rpc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz",
+      "integrity": "sha512-FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "k-bucket": "^5.0.0",
+        "k-rpc-socket": "^1.7.2",
+        "randombytes": "^2.0.5"
+      }
+    },
+    "node_modules/k-rpc-socket": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
+      "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^2.0.0",
+        "chrome-dgram": "^3.0.2",
+        "chrome-dns": "^1.0.0",
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/k-rpc-socket/node_modules/bencode": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.3.tgz",
+      "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7732,6 +8841,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/last-one-wins": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
+      "integrity": "sha512-t+KLJFkHPQk8lfN6WBOiGkiUXoub+gnb2XTYI2P3aiISL+94xgZ1vgz1SXN/N4hthuOoLXarXfBZPUruyjQtfA==",
+      "license": "MIT"
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
@@ -8000,11 +9115,47 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/load-ip-set": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/load-ip-set/-/load-ip-set-3.0.2.tgz",
+      "integrity": "sha512-UD1GM3CLlkC3b0gAKIxd+6SFJb1WQttWyYhwvjdWjGpJKzu32HnaSMfWtUtVgRtFY+K5vgrvecuVQLRxx5Ojag==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch-ponyfill": "^1.0.1",
+        "ip-set": "^3.0.0",
+        "netmask": "^2.0.1",
+        "once": "^1.4.0",
+        "queue-microtask": "^1.2.3",
+        "split": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -8060,6 +9211,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
+      "integrity": "sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -8071,6 +9234,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/lt_donthave": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/lt_donthave/-/lt_donthave-2.0.7.tgz",
+      "integrity": "sha512-FdfetmgzUr0IC2ZXHaOhAMEsvw8BFo7kDM7JzfYsJ5pO5+xzjfZIPdLSQWE4+/UTlQA7D8IU5ZJ0LTuLE4BRBQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.2.0",
+        "unordered-array-remove": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -8079,6 +9269,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magnet-uri": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/magnet-uri/-/magnet-uri-7.0.8.tgz",
+      "integrity": "sha512-cRzrGzw6nvjj+CMQczrVGZbcZfxhth4uSIQf7PGzACW11UsptwrQbAXTuUek7k3xG1HiFZJnkGpgjY2a5Y5Pgw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@thaunknown/thirty-two": "^1.0.5",
+        "bep53-range": "^2.0.0",
+        "uint8-util": "^2.2.6"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/make-dir": {
@@ -8153,6 +9371,15 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/memory-chunk-store": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/memory-chunk-store/-/memory-chunk-store-1.3.5.tgz",
+      "integrity": "sha512-E1Xc1U4ifk/FkC2ZsWhCaW1xg9HbE/OBmQTLe2Tr9c27YPSLbW7kw1cnb3kQWD1rDtErFJHa7mB9EVrs7aTx9g==",
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.3"
       }
     },
     "node_modules/meow": {
@@ -8293,6 +9520,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8398,7 +9631,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8454,6 +9686,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/modify-filename": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
@@ -8463,9 +9701,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -8485,6 +9724,19 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8497,6 +9749,15 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-abi": {
@@ -8548,6 +9809,57 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-datachannel": {
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.32.3.tgz",
+      "integrity": "sha512-Aok1ZhLsll472lRefgWYuWJ0070jh0ecHravTdRyZEmoESumebMEQV8Y+poBwSW2ZbEwAokAOGsK5Cu8pDDT2g==",
+      "hasInstallScript": true,
+      "license": "MPL 2.0",
+      "dependencies": {
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-gyp": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
@@ -8571,6 +9883,18 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-gyp/node_modules/isexe": {
@@ -8675,6 +9999,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -8745,7 +10096,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8864,6 +10214,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-torrent": {
+      "version": "11.0.21",
+      "resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-11.0.21.tgz",
+      "integrity": "sha512-yQeIv9PaT/AQGhyyYpj0h2W5iP7Eka5CyaG6ECw/4SeoFK9lcIxCG3EqBHisrM3LA+LrtGzo68DLcE4rSd5YLA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^4.0.1",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "get-stdin": "^10.0.0",
+        "magnet-uri": "^7.0.8",
+        "queue-microtask": "^1.2.3",
+        "uint8-util": "^2.2.6"
+      },
+      "bin": {
+        "parse-torrent": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8893,7 +10277,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8942,6 +10325,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/piece-length": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/piece-length/-/piece-length-2.0.1.tgz",
+      "integrity": "sha512-dBILiDmm43y0JPISWEmVGKBETQjwJe6mSU9GND+P9KW0SJGUwoU/odyH1nbalOP9i8WSYuqf1lQnaj92Bhw+Ug==",
+      "license": "MIT"
     },
     "node_modules/pkg-up": {
       "version": "3.1.0",
@@ -9127,6 +10516,57 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9204,7 +10644,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -9269,7 +10708,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9285,6 +10723,12 @@
         }
       ]
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "license": "MIT"
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -9295,6 +10739,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/random-access-file": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-4.1.2.tgz",
+      "integrity": "sha512-GQM6R78DceZDcQod8KxlDFwXIiUvlvuy1EOzxTDsjuDjW5NlnlZi0MOk6iI4itAj/2vcvdqcEExYbVpC/dJcEw==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "random-access-storage": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "fs-native-extensions": "^1.3.1"
+      }
+    },
+    "node_modules/random-access-storage": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-3.0.2.tgz",
+      "integrity": "sha512-Es9maUyWdJXWKckKy9s1+vT+DEgAt+PBb9lxPaake/0EDUsHehloKGv9v1zimS2V3gpFAcQXubvc1Rgci2sDPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bare-events": "^2.2.0",
+        "queue-tick": "^1.0.0"
+      }
+    },
+    "node_modules/random-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/random-iterate/-/random-iterate-1.0.1.tgz",
+      "integrity": "sha512-Jdsdnezu913Ot8qgKgSgs63XkAjEsnMcS1z+cC6D6TNXsUXsMxy0RpclF2pzGZTEiTXL9BiArdGTEexcv4nqcA==",
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -9357,6 +10840,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -9404,6 +10911,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/record-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.3.1"
       }
     },
     "node_modules/redent": {
@@ -9525,6 +11041,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
       }
     },
     "node_modules/require-directory": {
@@ -9797,7 +11326,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9815,6 +11343,49 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-series": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -9942,11 +11513,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -10013,7 +11579,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -10025,7 +11590,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10102,8 +11666,52 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -10154,11 +11762,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smob": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.1.1.tgz",
       "integrity": "sha512-i5aqEBPnDv9d77+NDxfjROtywxzNdAVNyaOr+RsLhM28Ts+Ar7luIp/Q+SBYa6wv/7BBcOpEkrhtDxsl2WA9Jg==",
       "dev": true
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
     },
     "node_modules/sort-keys": {
       "version": "1.1.2",
@@ -10242,6 +11874,28 @@
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
+    "node_modules/speed-limiter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/speed-limiter/-/speed-limiter-1.0.2.tgz",
+      "integrity": "sha512-Ax+TbUOho84bWUc3AKqWtkIvAIVws7d6QI4oJkgH4yQ5Yil+lR3vjd/7qd51dHKGzS5bFxg0++QwyNRN7s6rZA==",
+      "license": "MIT",
+      "dependencies": {
+        "limiter": "^1.1.5",
+        "streamx": "^2.10.3"
+      }
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -10268,11 +11922,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -10282,7 +11946,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -10343,6 +12006,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/string2compact": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/string2compact/-/string2compact-2.0.2.tgz",
+      "integrity": "sha512-ZUUIyrS+sSj84gR6fFoz/boiqCptyw37/hMxIehReuf6ekpJOlwSXhTfEasqc5t3QucBXi2ghwLlHOSC8hjEaw==",
+      "license": "MIT",
+      "dependencies": {
+        "addr-to-ip-port": "^2.0.0",
+        "ipaddr.js": "2.0.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/string2compact/node_modules/ipaddr.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -10361,6 +12046,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-indent": {
@@ -10444,6 +12141,54 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -10452,6 +12197,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp": {
@@ -10557,11 +12311,45 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/throughput": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/throughput/-/throughput-1.0.2.tgz",
+      "integrity": "sha512-jvK1ZXuhsggjb3qYQjMiU/AVYYiTeqT5thWvYR2yuy2LGM84P5MSSyAinwHahGsdBYKR9m9HncVR/3f3nFKkxg==",
+      "license": "MIT"
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
+    },
+    "node_modules/timeout-refresh": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.3.tgz",
+      "integrity": "sha512-Mz0CX4vBGM5lj8ttbIFt7o4ZMxk/9rgudJRh76EvB7xXZMur7T/cjRiH2w4Fmkq0zxf2QpM8IFvOSRn8FEu3gA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -10673,6 +12461,62 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/torrent-discovery": {
+      "version": "11.0.21",
+      "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-11.0.21.tgz",
+      "integrity": "sha512-x+RGu60qJp2u4S7B7XglyYCrfDJWKB0RIexODlA5dpBpMh94q4MbmRjusdbvxN+XD4NHhpwEfub/CRA9pUXjEQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "bittorrent-dht": "^11.0.12",
+        "bittorrent-lsd": "^2.0.3",
+        "bittorrent-tracker": "^11.2.3",
+        "debug": "^4.4.3",
+        "run-parallel": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/torrent-piece": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/torrent-piece/-/torrent-piece-4.0.1.tgz",
+      "integrity": "sha512-bL5lLm0CknuXMJ3c8Xw+27etPTH7P1vLXwEASQ3bktZlWV2ZEkCW1l0ssV6Y9EHpcUlf0aqB9x49bkgMA4JrHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uint8-util": "^2.1.9"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -10725,6 +12569,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10775,6 +12631,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uint8-util": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/uint8-util/-/uint8-util-2.2.6.tgz",
+      "integrity": "sha512-r+ZjS8CzPhtPF771ROOadUoqC40OVdiMKBI8lTfJQWb4W7+73sMBwMYmai/uvNcmZ7tBJJyZSad03yMWIt3RQg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/unbox-primitive": {
@@ -10860,6 +12725,19 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/unordered-array-remove": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unordered-array-remove/-/unordered-array-remove-1.0.2.tgz",
+      "integrity": "sha512-45YsfD6svkgaCBNyvD+dFHm4qFX9g3wRSIVgWVPtm2OCnphvPxzJoe20ATsiNpNJrmzHifnxm+BN5F7gFT/4gw==",
+      "license": "MIT"
+    },
+    "node_modules/unordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -10973,6 +12851,77 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/ut_metadata": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ut_metadata/-/ut_metadata-5.0.1.tgz",
+      "integrity": "sha512-V+6jKXXvkH8YQDFeSpvjSkn7Yiz7Juz3LhIkA1QhxuvOjhrqwlZKJfRMOjVSEW/mPa9Bpk4hvFOCim98tzR04w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^4.0.0",
+        "bitfield": "^5.0.0",
+        "debug": "^4.2.0",
+        "uint8-util": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ut_pex": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ut_pex/-/ut_pex-5.0.2.tgz",
+      "integrity": "sha512-tPWnEmFIpn47IgZ3CyMzA4onr6zGtBrR+DVtRGoyCpC59OgqELvj9jkzLuisCwIH5FdUQiwqtXtsiAWwpUfrKw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "bencode": "^4.0.1",
+        "compact2string": "^1.4.1",
+        "string2compact": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -10984,7 +12933,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -10993,6 +12941,42 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utp-native": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.5.3.tgz",
+      "integrity": "sha512-sWTrWYXPhhWJh+cS2baPzhaZc89zwlWCfwSthUjGhLkZztyPhcQllo+XVVCbNGi7dhyRlxkWxN4NKU6FbA9Y8w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "napi-macros": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.0.2",
+        "timeout-refresh": "^1.0.0",
+        "unordered-set": "^2.0.1"
+      },
+      "bin": {
+        "ucat": "ucat.js"
+      },
+      "engines": {
+        "node": ">=8.12"
+      }
+    },
+    "node_modules/utp-native/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -11102,6 +13086,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webcrypto-core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
@@ -11116,11 +13109,101 @@
         "tslib": "^2.8.1"
       }
     },
+    "node_modules/webrtc-polyfill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/webrtc-polyfill/-/webrtc-polyfill-1.2.2.tgz",
+      "integrity": "sha512-t/H2OySa7lZSq2f5j4whmr+IWCl5TqF4daGotE8VhPP7U+E4x5x8MK1wqOkqlb4xxRlag4kBB9enU4oxNk//+g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-datachannel": "^0.32.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/webtorrent": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/webtorrent/-/webtorrent-3.0.16.tgz",
+      "integrity": "sha512-oryVor+AGWiNbI4zBT58CKw5MrUYz2GxP5fleHyIhucqwTYAl6pjGkDTjCPGiY5VZCPnVhhhlt+eFov85ZgZKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@silentbot1/nat-api": "^0.4.9",
+        "@thaunknown/simple-peer": "^10.1.1",
+        "@webtorrent/http-node": "^1.3.0",
+        "addr-to-ip-port": "^2.0.0",
+        "bitfield": "^5.0.1",
+        "bittorrent-dht": "^11.0.12",
+        "bittorrent-protocol": "^5.0.6",
+        "cache-chunk-store": "^3.2.2",
+        "chunk-store-iterator": "^1.0.4",
+        "cpus": "^1.0.3",
+        "create-torrent": "^6.1.2",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "debug": "^4.4.3",
+        "escape-html": "^1.0.3",
+        "fs-chunk-store": "^5.0.1",
+        "fsa-chunk-store": "^1.3.0",
+        "immediate-chunk-store": "^2.2.0",
+        "join-async-iterator": "^1.1.1",
+        "load-ip-set": "^3.0.2",
+        "lt_donthave": "^2.0.7",
+        "memory-chunk-store": "^1.3.5",
+        "mime": "^3.0.0",
+        "once": "^1.4.0",
+        "parse-torrent": "^11.0.21",
+        "pump": "^3.0.4",
+        "queue-microtask": "^1.2.3",
+        "random-iterate": "^1.0.1",
+        "range-parser": "^1.2.1",
+        "run-parallel": "^1.2.0",
+        "run-parallel-limit": "^1.1.0",
+        "speed-limiter": "^1.0.2",
+        "streamx": "2.25.0",
+        "throughput": "^1.0.2",
+        "torrent-discovery": "^11.0.21",
+        "torrent-piece": "^4.0.1",
+        "uint8-util": "^2.2.6",
+        "unordered-array-remove": "^1.0.2",
+        "ut_metadata": "^5.0.1",
+        "ut_pex": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "utp-native": "^2.5.3"
+      }
+    },
+    "node_modules/webtorrent/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -11146,6 +13229,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/which-typed-array": {
       "version": "1.1.9",
@@ -11197,8 +13287,50 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
@@ -13315,6 +15447,19 @@
       "dev": true,
       "optional": true
     },
+    "@silentbot1/nat-api": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@silentbot1/nat-api/-/nat-api-0.4.9.tgz",
+      "integrity": "sha512-Bm2Fr0sJyGr4B/XgKjQxjGe7Rzs/OlK91OIHsghObxhP3Y4j2y8o7Xjlledu/pxzFEIWaTbZIBSl8ABqoP/WhQ==",
+      "requires": {
+        "chrome-dgram": "^3.0.6",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "debug": "^4.4.0",
+        "default-gateway": "^7.2.2",
+        "unordered-array-remove": "^1.0.2",
+        "xml2js": "^0.6.2"
+      }
+    },
     "@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -13328,6 +15473,45 @@
       "dev": true,
       "requires": {
         "defer-to-connect": "^2.0.0"
+      }
+    },
+    "@thaunknown/simple-peer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@thaunknown/simple-peer/-/simple-peer-10.1.1.tgz",
+      "integrity": "sha512-cQHGk4J7eXL9zmGELnFrB9YszZBZGE6T06OH/iCAN6H/ObckK84pyddTlVU45PEkeVKyICzJbhPgeL9xwF64Mw==",
+      "requires": {
+        "debug": "^4.4.3",
+        "err-code": "^3.0.1",
+        "streamx": "^2.25.0",
+        "uint8-util": "^2.2.6",
+        "webrtc-polyfill": "^1.2.1"
+      },
+      "dependencies": {
+        "err-code": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+          "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+        }
+      }
+    },
+    "@thaunknown/simple-websocket": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@thaunknown/simple-websocket/-/simple-websocket-9.1.4.tgz",
+      "integrity": "sha512-NgEFe6TFqRaQvRJF7kFTg0qz7Z28lNiTmAgIY0voNMxrrZtasZKFR3KtN6MtYeS8fOLzn7RLLKQgpV0b8dvCng==",
+      "requires": {
+        "debug": "^4.4.3",
+        "queue-microtask": "^1.2.3",
+        "streamx": "^2.25.0",
+        "uint8-util": "^2.2.6",
+        "ws": "^8.20.1"
+      }
+    },
+    "@thaunknown/thirty-two": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@thaunknown/thirty-two/-/thirty-two-1.0.5.tgz",
+      "integrity": "sha512-Q53KyCXweV1CS62EfqtPDqfpksn5keQ59PGqzzkK+g8Vif1jB4inoBCcs/BUSdsqddhE3G+2Fn+4RX3S6RqT0A==",
+      "requires": {
+        "uint8-util": "^2.2.5"
       }
     },
     "@tybys/wasm-util": {
@@ -13453,6 +15637,15 @@
         "@types/node": "*"
       }
     },
+    "@webtorrent/http-node": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@webtorrent/http-node/-/http-node-1.3.0.tgz",
+      "integrity": "sha512-GWZQKroPES4z91Ijx6zsOsb7+USOxjy66s8AoTWg0HiBBdfnbtf9aeh3Uav0MgYn4BL8Q7tVSUpd0gGpngKGEQ==",
+      "requires": {
+        "freelist": "^1.0.3",
+        "http-parser-js": "^0.4.3"
+      }
+    },
     "@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -13464,6 +15657,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
       "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.8",
@@ -13486,6 +15687,11 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "addr-to-ip-port": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/addr-to-ip-port/-/addr-to-ip-port-2.0.0.tgz",
+      "integrity": "sha512-9bYbtjamtdLHZSqVIUXhilOryNPiL+x+Q5J/Unpg4VY3ZIkK3fT52UoErj1NdUeVm3J1t2iBEAur4Ywbl/bahw=="
     },
     "agent-base": {
       "version": "7.1.4",
@@ -13875,6 +16081,12 @@
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "dev": true
     },
+    "b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "requires": {}
+    },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
@@ -13941,11 +16153,94 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "optional": true,
+      "requires": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      }
+    },
+    "bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "requires": {}
+    },
+    "bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "requires": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      }
+    },
+    "bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "optional": true,
+      "requires": {
+        "bare-semver": "^1.0.0"
+      }
+    },
+    "bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="
+    },
+    "bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "optional": true
+    },
+    "bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "requires": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      }
+    },
+    "bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "requires": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bencode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-4.0.1.tgz",
+      "integrity": "sha512-/bCR3FvgfB8AZk4LlowShU+nfaTNRM2vruJ9aejDa5LpgkCoRjFyEauFiZFxbpxVxQbBFapYCN42Er2dkE/Qgw==",
+      "requires": {
+        "uint8-util": "^2.2.2"
+      }
+    },
+    "bep53-range": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bep53-range/-/bep53-range-2.0.1.tgz",
+      "integrity": "sha512-VWN7j7sqUssWD6ROZe2m709YL3u5A1IAx1qvAbH3DAhszHt4WPvCzJLRJ+mzmZn1qWIb4mpflwdn95qezz3n8g=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -13953,6 +16248,123 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "optional": true
+    },
+    "bitfield": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bitfield/-/bitfield-5.0.1.tgz",
+      "integrity": "sha512-81mvFHCa0L1HsDdKVCTkPKZZ6KFdyXgfQNoneFT7Qk5/PZeBWdPkTFa4KttbR8uHszfjiqOJbeahLOPfCqw4cw=="
+    },
+    "bittorrent-dht": {
+      "version": "11.0.12",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-11.0.12.tgz",
+      "integrity": "sha512-bFmQq874HMIBon/6KNMf/U1OG+UxJ0UzI9oPra2IRlZLuPA7VwBiA7uEpWaO2ww8G76OFjxB1p1XCOS94FuCPQ==",
+      "requires": {
+        "bencode": "^4.0.1",
+        "debug": "^4.4.3",
+        "k-bucket": "^5.1.0",
+        "k-rpc": "^5.1.0",
+        "last-one-wins": "^1.0.4",
+        "lru": "^3.1.0",
+        "randombytes": "^2.1.0",
+        "record-cache": "^1.2.0"
+      }
+    },
+    "bittorrent-lsd": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bittorrent-lsd/-/bittorrent-lsd-2.0.3.tgz",
+      "integrity": "sha512-FE4ImhpJZo8ahzDS/Qk1Ol+3Ea1sIhCPWE2WSjiv1s8YoCSEf7JBL3bbCJW5hdVNK5ohtZ3vH5xGjZ9QWFiatQ==",
+      "requires": {
+        "chrome-dgram": "^3.0.6",
+        "debug": "^4.2.0"
+      }
+    },
+    "bittorrent-peerid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bittorrent-peerid/-/bittorrent-peerid-2.0.2.tgz",
+      "integrity": "sha512-V2iUvbtv31uLA8XFxbhB3f/fKTxWGaa6FI/3wSm93YAS/DS8IkeRWCyYGQ13Xbc9ajR40nsxNjGtVt7OHB3VOQ=="
+    },
+    "bittorrent-protocol": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/bittorrent-protocol/-/bittorrent-protocol-5.0.6.tgz",
+      "integrity": "sha512-qI0PeZpMBQyhvMGvsw0aJjUSMJwMNc6lLzD1TX3Q1MmzA3s3fNZrk/PKHpzrjyR9xNGBZeQ5ZuT3Stym6AUq+Q==",
+      "requires": {
+        "bencode": "^4.0.1",
+        "bitfield": "^5.0.1",
+        "debug": "^4.4.3",
+        "streamx": "^2.26.0",
+        "throughput": "^1.0.2",
+        "uint8-util": "^2.2.6",
+        "unordered-array-remove": "^1.0.2"
+      },
+      "dependencies": {
+        "streamx": {
+          "version": "2.28.0",
+          "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+          "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+          "requires": {
+            "events-universal": "^1.0.0",
+            "fast-fifo": "^1.3.2",
+            "text-decoder": "^1.1.0"
+          }
+        }
+      }
+    },
+    "bittorrent-tracker": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/bittorrent-tracker/-/bittorrent-tracker-11.2.3.tgz",
+      "integrity": "sha512-i9pWOf1YAQWyTjDnpWwcTfEYDi5XwqD6f48pKmIHByb7x2XU86CqK+IsyMy1buKkDZ3rDKht2jIeKCZf1Dmd8g==",
+      "requires": {
+        "@thaunknown/simple-peer": "^10.0.8",
+        "@thaunknown/simple-websocket": "^9.1.3",
+        "bencode": "^4.0.0",
+        "bittorrent-peerid": "^2.0.0",
+        "bufferutil": "^4.0.8",
+        "chrome-dgram": "^3.0.6",
+        "compact2string": "^1.4.1",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "debug": "^4.3.4",
+        "ip": "^2.0.1",
+        "lru": "^3.1.0",
+        "minimist": "^1.2.8",
+        "once": "^1.4.0",
+        "queue-microtask": "^1.2.3",
+        "random-iterate": "^1.0.1",
+        "run-parallel": "^1.2.0",
+        "run-series": "^1.1.9",
+        "socks": "^2.8.3",
+        "string2compact": "^2.0.1",
+        "uint8-util": "^2.2.5",
+        "unordered-array-remove": "^1.0.2",
+        "utf-8-validate": "^6.0.4",
+        "ws": "^8.17.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "block-iterator": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/block-iterator/-/block-iterator-1.1.2.tgz",
+      "integrity": "sha512-yAHUP44v2K25xLPdrgVTgwtuQctlullzjczu9CoUZom5AP3g4p1R1+aWHjS1GHG9JtcSUVUnbEPiuXiW5YZ24w=="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -14064,11 +16476,29 @@
         "update-browserslist-db": "^1.1.1"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
     },
     "builder-util": {
       "version": "26.15.3",
@@ -14167,6 +16597,15 @@
       "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
       "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
       "dev": true
+    },
+    "cache-chunk-store": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/cache-chunk-store/-/cache-chunk-store-3.2.2.tgz",
+      "integrity": "sha512-2lJdWbgHFFxcSth9s2wpId3CR3v1YC63KjP4T9WhpW7LWlY7Hiiei3QwwqzkWqlJTfR8lSy9F5kRQECeyj+yQA==",
+      "requires": {
+        "lru": "^3.1.0",
+        "queue-microtask": "^1.2.3"
+      }
     },
     "cacheable-lookup": {
       "version": "5.0.4",
@@ -14291,11 +16730,44 @@
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true
     },
+    "chrome-dgram": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.6.tgz",
+      "integrity": "sha512-bqBsUuaOiXiqxXt/zA/jukNJJ4oaOtc7ciwqJpZVEaaXwwxqgI2/ZdG02vXYWUhHGziDlvGMQWk0qObgJwVYKA==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "run-series": "^1.1.9"
+      }
+    },
+    "chrome-dns": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
+      "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
+      "requires": {
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "chrome-net": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.4.tgz",
+      "integrity": "sha512-Jzy2EnzmE+ligqIZUsmWnck9RBXLuUy6CaKyuNMtowFG3ZvLt8d+WBJCTPEludV0DHpIKjAOlwjFmTaEdfdWCw==",
+      "requires": {
+        "inherits": "^2.0.1"
+      }
+    },
     "chromium-pickle-js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
       "dev": true
+    },
+    "chunk-store-iterator": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chunk-store-iterator/-/chunk-store-iterator-1.0.4.tgz",
+      "integrity": "sha512-LGjzJNmk7W1mrdaBoJNztPumT2ACmgjHmI1AMm8aeGYOl4+LKaYC/yfnx27i++LiAtoe/dR+3jC8HRzb6gW4/A==",
+      "requires": {
+        "block-iterator": "^1.1.1"
+      }
     },
     "ci-info": {
       "version": "4.4.0",
@@ -14388,6 +16860,14 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
+    },
+    "compact2string": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/compact2string/-/compact2string-1.4.1.tgz",
+      "integrity": "sha512-3D+EY5nsRhqnOwDxveBv5T8wGo4DEvYxjDtPGmdOX+gfr5gE92c2RC0w2wa+xEefm07QuVqqcF3nZJUZ92l/og==",
+      "requires": {
+        "ipaddr.js": ">= 0.1.5"
+      }
     },
     "compare-version": {
       "version": "0.1.2",
@@ -14493,6 +16973,30 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
+    "cpus": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cpus/-/cpus-1.0.3.tgz",
+      "integrity": "sha512-PXHBvGLuL69u55IkLa5e5838fLhIMHxmkV4ge42a8alGyn7BtawYgI0hQ849EedvtHIOLNNH3i6eQU1BiE9SUA=="
+    },
+    "create-torrent": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/create-torrent/-/create-torrent-6.1.2.tgz",
+      "integrity": "sha512-PrqAy9matS8HquhCQp45SyTEgshxK21SiZt9RxFNHybTWp3lYICebjj4zENl6jpjQGzuJ8DdI92TJuV73CO4YA==",
+      "requires": {
+        "bencode": "^4.0.1",
+        "block-iterator": "^1.1.2",
+        "fast-readable-async-iterator": "^2.0.0",
+        "is-file": "^1.0.0",
+        "join-async-iterator": "^1.1.1",
+        "junk": "^4.0.1",
+        "minimist": "^1.2.8",
+        "once": "^1.4.0",
+        "piece-length": "^2.0.1",
+        "queue-microtask": "^1.2.3",
+        "run-parallel": "^1.2.0",
+        "uint8-util": "^2.2.6"
+      }
+    },
     "cross-dirname": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
@@ -14501,16 +17005,29 @@
       "optional": true,
       "peer": true
     },
+    "cross-fetch-ponyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch-ponyfill/-/cross-fetch-ponyfill-1.0.3.tgz",
+      "integrity": "sha512-uOBkDhUAGAbx/FEzNKkOfx3w57H8xReBBXoZvUnOKTI0FW0Xvrj3GrYv2iZXUqlffC1LMGfQzhmBM/ke+6eTDA==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.3.0"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
     },
     "debounce-fn": {
       "version": "4.0.0",
@@ -14521,11 +17038,11 @@
       }
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       }
     },
     "decamelize": {
@@ -14562,7 +17079,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "requires": {
         "mimic-response": "^3.1.0"
       },
@@ -14570,10 +17086,14 @@
         "mimic-response": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "dev": true
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
         }
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -14586,6 +17106,14 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
+    },
+    "default-gateway": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
+      "integrity": "sha512-AD7TrdNNPXRZIGw63dw+lnGmT4v7ggZC5NHNJgAYWm5njrwoze1q5JSAW9YuLy2tjnoLUG/r8FEB93MCh9QJPg==",
+      "requires": {
+        "execa": "^7.1.1"
+      }
     },
     "defer-to-connect": {
       "version": "2.0.1",
@@ -14667,8 +17195,7 @@
     "detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
     },
     "detect-node": {
       "version": "2.1.0",
@@ -15071,7 +17598,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -15500,6 +18026,60 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "requires": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        }
+      }
+    },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -15581,6 +18161,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -15606,6 +18191,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "fast-readable-async-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-readable-async-iterator/-/fast-readable-async-iterator-2.0.0.tgz",
+      "integrity": "sha512-8Sld+DuyWRIftl86ZguJxR2oXCBccOiJxrY/Rj9/7ZBynW8pYMWzIcqxFL1da+25jaWJZVa+HHX/8SsA21JdTA=="
+    },
     "fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -15618,6 +18208,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
       }
     },
     "file-entry-cache": {
@@ -15657,6 +18256,11 @@
           }
         }
       }
+    },
+    "filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="
     },
     "fill-range": {
       "version": "7.1.1",
@@ -15744,15 +18348,46 @@
         "mime-types": "^2.1.35"
       }
     },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
+    "freelist": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/freelist/-/freelist-1.0.3.tgz",
+      "integrity": "sha512-Ji7fEnMdZDGbS5oXElpRJsn9jPvBR8h/037D3bzreNmS8809cISq/2D9//JbA/TaZmkkN8cmecXwmQHmM+NHhg=="
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
+    "fs-chunk-store": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fs-chunk-store/-/fs-chunk-store-5.0.1.tgz",
+      "integrity": "sha512-bhD1YfAzdOugxu4VepYjxvzZwik9Qunn69Ogj47DZmogD6h/VkD/4vArNRoQ+kPYYOFqex3c9Ob2iAOkNYdkgw==",
+      "requires": {
+        "filename-reserved-regex": "^3.0.0",
+        "queue-microtask": "^1.2.2",
+        "random-access-file": "^4.0.0",
+        "run-parallel": "^1.1.2",
+        "thunky": "^1.0.1",
+        "uint8-util": "^2.2.5"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -15763,6 +18398,16 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      }
+    },
+    "fs-native-extensions": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
+      "integrity": "sha512-nuZLFm9mGCxvyi7Llww/J4OyifKCS21nEUTAmnlTZp3FObPOvA32aCedCmt4Z+8yk+caqfClNaSCfn/P7T7FLQ==",
+      "optional": true,
+      "requires": {
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.0"
       }
     },
     "fs-readdir-recursive": {
@@ -15776,6 +18421,14 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "fsa-chunk-store": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fsa-chunk-store/-/fsa-chunk-store-1.3.0.tgz",
+      "integrity": "sha512-0WCfuxqqSB6Tz/g7Ar/nwAxMoigXaIXuvfrnLIEFYIA9uc6w9eNaHuBGzU1X3lyM4cpLKCOTUmKAA/gCiTvzMQ==",
+      "requires": {
+        "filename-reserved-regex": "^3.0.0"
+      }
     },
     "fsevents": {
       "version": "2.3.3",
@@ -15845,6 +18498,11 @@
         "es-object-atoms": "^1.0.0"
       }
     },
+    "get-stdin": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-10.0.0.tgz",
+      "integrity": "sha512-eWSePJ4zXFdqz+/Lyfopob4rIcoF/U2XfE8nJc7iZV6lnebWc9k7DoQQpX+2a9jc0AOvBsXvbe5YkjXl/MHbpg=="
+    },
     "get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -15863,6 +18521,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.2.3",
@@ -16073,6 +18736,11 @@
         "toidentifier": "1.0.1"
       }
     },
+    "http-parser-js": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha512-u8u5ZaG0Tr/VvHlucK2ufMuOp4/5bvwgneXle+y228K5rMbJOlVjThONcaAw3ikAy8b2OO9RfEucdMHFz3UWMA=="
+    },
     "http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -16103,11 +18771,29 @@
         "debug": "4"
       }
     },
+    "human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ=="
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
+    },
+    "immediate-chunk-store": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/immediate-chunk-store/-/immediate-chunk-store-2.2.0.tgz",
+      "integrity": "sha512-1bHBna0hCa6arRXicu91IiL9RvvkbNYLVq+mzWdaLGZC3hXvX4doh8e1dLhMKez5siu63CYgO5NrGJbRX5lbPA==",
+      "requires": {
+        "queue-microtask": "^1.2.3"
+      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -16146,6 +18832,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -16155,6 +18846,24 @@
         "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    },
+    "ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
+    },
+    "ip-set": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ip-set/-/ip-set-3.0.0.tgz",
+      "integrity": "sha512-EkKzllMFYKMHOoeNxM8v10IJM2n9K6L3ruaQx4A/5RrkOInV8cjp9IwkVU0/cpzwwkq1zGNudrAdCjSR97Rf5w==",
+      "requires": {
+        "ip-address": "^10.0.1"
       }
     },
     "ipaddr.js": {
@@ -16246,6 +18955,11 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
+    },
+    "is-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-file/-/is-file-1.0.0.tgz",
+      "integrity": "sha512-ZGMuc+xA8mRnrXtmtf2l/EkIW2zaD2LSBWlaOVEF6yH4RTndHob65V4SwWWdtGKVthQfXPVKsXqw4TDUjbVxVQ=="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -16344,6 +19058,11 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+    },
     "is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -16399,8 +19118,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "jake": {
       "version": "10.9.4",
@@ -16418,6 +19136,11 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true
+    },
+    "join-async-iterator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/join-async-iterator/-/join-async-iterator-1.1.1.tgz",
+      "integrity": "sha512-ATse+nuNeKZ9K1y27LKdvPe/GCe9R/u9dw9vI248e+vILeRK3IcJP4JUPAlSmKRCDK0cKhEwfmiw4Skqx7UnGQ=="
     },
     "jquery": {
       "version": "3.7.1",
@@ -16497,6 +19220,47 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "junk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ=="
+    },
+    "k-bucket": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
+      "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "k-rpc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz",
+      "integrity": "sha512-FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==",
+      "requires": {
+        "k-bucket": "^5.0.0",
+        "k-rpc-socket": "^1.7.2",
+        "randombytes": "^2.0.5"
+      }
+    },
+    "k-rpc-socket": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
+      "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
+      "requires": {
+        "bencode": "^2.0.0",
+        "chrome-dgram": "^3.0.2",
+        "chrome-dns": "^1.0.0",
+        "chrome-net": "^3.3.2"
+      },
+      "dependencies": {
+        "bencode": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.3.tgz",
+          "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w=="
+        }
+      }
+    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -16511,6 +19275,11 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
+    },
+    "last-one-wins": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
+      "integrity": "sha512-t+KLJFkHPQk8lfN6WBOiGkiUXoub+gnb2XTYI2P3aiISL+94xgZ1vgz1SXN/N4hthuOoLXarXfBZPUruyjQtfA=="
     },
     "lazy-val": {
       "version": "1.0.5",
@@ -16624,11 +19393,29 @@
       "dev": true,
       "optional": true
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "load-ip-set": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/load-ip-set/-/load-ip-set-3.0.2.tgz",
+      "integrity": "sha512-UD1GM3CLlkC3b0gAKIxd+6SFJb1WQttWyYhwvjdWjGpJKzu32HnaSMfWtUtVgRtFY+K5vgrvecuVQLRxx5Ojag==",
+      "requires": {
+        "cross-fetch-ponyfill": "^1.0.1",
+        "ip-set": "^3.0.0",
+        "netmask": "^2.0.1",
+        "once": "^1.4.0",
+        "queue-microtask": "^1.2.3",
+        "split": "^1.0.1"
+      }
     },
     "locate-path": {
       "version": "6.0.0",
@@ -16673,12 +19460,29 @@
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "dev": true
     },
+    "lru": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
+      "integrity": "sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==",
+      "requires": {
+        "inherits": "^2.0.1"
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
         "yallist": "^4.0.0"
+      }
+    },
+    "lt_donthave": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/lt_donthave/-/lt_donthave-2.0.7.tgz",
+      "integrity": "sha512-FdfetmgzUr0IC2ZXHaOhAMEsvw8BFo7kDM7JzfYsJ5pO5+xzjfZIPdLSQWE4+/UTlQA7D8IU5ZJ0LTuLE4BRBQ==",
+      "requires": {
+        "debug": "^4.2.0",
+        "unordered-array-remove": "^1.0.2"
       }
     },
     "magic-string": {
@@ -16688,6 +19492,16 @@
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "magnet-uri": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/magnet-uri/-/magnet-uri-7.0.8.tgz",
+      "integrity": "sha512-cRzrGzw6nvjj+CMQczrVGZbcZfxhth4uSIQf7PGzACW11UsptwrQbAXTuUek7k3xG1HiFZJnkGpgjY2a5Y5Pgw==",
+      "requires": {
+        "@thaunknown/thirty-two": "^1.0.5",
+        "bep53-range": "^2.0.0",
+        "uint8-util": "^2.2.6"
       }
     },
     "make-dir": {
@@ -16739,6 +19553,14 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+    },
+    "memory-chunk-store": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/memory-chunk-store/-/memory-chunk-store-1.3.5.tgz",
+      "integrity": "sha512-E1Xc1U4ifk/FkC2ZsWhCaW1xg9HbE/OBmQTLe2Tr9c27YPSLbW7kw1cnb3kQWD1rDtErFJHa7mB9EVrs7aTx9g==",
+      "requires": {
+        "queue-microtask": "^1.2.3"
+      }
     },
     "meow": {
       "version": "10.1.5",
@@ -16835,6 +19657,11 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -16904,8 +19731,7 @@
     "minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -16943,21 +19769,37 @@
         "minimist": "^1.2.6"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "modify-filename": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
       "integrity": "sha512-EickqnKq3kVVaZisYuCxhtKbZjInCuwgwZWyAmRIp1NTMhri7r3380/uqwrUHfaDiPzLVTuoNy4whX66bxPVog=="
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true
+    },
+    "napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
+    "napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -16969,6 +19811,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="
     },
     "node-abi": {
       "version": "4.33.0",
@@ -17002,6 +19849,29 @@
           "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
           "dev": true
         }
+      }
+    },
+    "node-datachannel": {
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.32.3.tgz",
+      "integrity": "sha512-Aok1ZhLsll472lRefgWYuWJ0070jh0ecHravTdRyZEmoESumebMEQV8Y+poBwSW2ZbEwAokAOGsK5Cu8pDDT2g==",
+      "requires": {
+        "prebuild-install": "^7.1.3"
+      }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-gyp": {
@@ -17051,6 +19921,12 @@
         }
       }
     },
+    "node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "optional": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -17084,6 +19960,21 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true
+    },
+    "npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "requires": {
+        "path-key": "^4.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+        }
+      }
     },
     "object-inspect": {
       "version": "1.13.4",
@@ -17131,7 +20022,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -17212,6 +20102,19 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-torrent": {
+      "version": "11.0.21",
+      "resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-11.0.21.tgz",
+      "integrity": "sha512-yQeIv9PaT/AQGhyyYpj0h2W5iP7Eka5CyaG6ECw/4SeoFK9lcIxCG3EqBHisrM3LA+LrtGzo68DLcE4rSd5YLA==",
+      "requires": {
+        "bencode": "^4.0.1",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "get-stdin": "^10.0.0",
+        "magnet-uri": "^7.0.8",
+        "queue-microtask": "^1.2.3",
+        "uint8-util": "^2.2.6"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -17231,8 +20134,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -17262,6 +20164,11 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
+    },
+    "piece-length": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/piece-length/-/piece-length-2.0.1.tgz",
+      "integrity": "sha512-dBILiDmm43y0JPISWEmVGKBETQjwJe6mSU9GND+P9KW0SJGUwoU/odyH1nbalOP9i8WSYuqf1lQnaj92Bhw+Ug=="
     },
     "pkg-up": {
       "version": "3.1.0",
@@ -17383,6 +20290,40 @@
         }
       }
     },
+    "prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "node-abi": {
+          "version": "3.94.0",
+          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+          "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+          "requires": {
+            "semver": "^7.3.5"
+          }
+        },
+        "semver": {
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -17441,7 +20382,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -17487,14 +20427,51 @@
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
+    },
+    "random-access-file": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-4.1.2.tgz",
+      "integrity": "sha512-GQM6R78DceZDcQod8KxlDFwXIiUvlvuy1EOzxTDsjuDjW5NlnlZi0MOk6iI4itAj/2vcvdqcEExYbVpC/dJcEw==",
+      "requires": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "fs-native-extensions": "^1.3.1",
+        "random-access-storage": "^3.0.0"
+      }
+    },
+    "random-access-storage": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-3.0.2.tgz",
+      "integrity": "sha512-Es9maUyWdJXWKckKy9s1+vT+DEgAt+PBb9lxPaake/0EDUsHehloKGv9v1zimS2V3gpFAcQXubvc1Rgci2sDPQ==",
+      "requires": {
+        "bare-events": "^2.2.0",
+        "queue-tick": "^1.0.0"
+      }
+    },
+    "random-iterate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/random-iterate/-/random-iterate-1.0.1.tgz",
+      "integrity": "sha512-Jdsdnezu913Ot8qgKgSgs63XkAjEsnMcS1z+cC6D6TNXsUXsMxy0RpclF2pzGZTEiTXL9BiArdGTEexcv4nqcA=="
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -17539,6 +20516,24 @@
         }
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+        }
+      }
+    },
     "read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -17579,6 +20574,14 @@
       "optional": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "record-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "requires": {
+        "b4a": "^1.3.1"
       }
     },
     "redent": {
@@ -17667,6 +20670,15 @@
           "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
           "dev": true
         }
+      }
+    },
+    "require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "optional": true,
+      "requires": {
+        "bare-addon-resolve": "^1.3.0"
       }
     },
     "require-directory": {
@@ -17867,10 +20879,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "run-series": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g=="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -17964,11 +20988,6 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -18022,7 +21041,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -18030,8 +21048,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
       "version": "1.1.0",
@@ -18080,8 +21097,22 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "simple-update-notifier": {
       "version": "2.0.0",
@@ -18119,11 +21150,25 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
     "smob": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.1.1.tgz",
       "integrity": "sha512-i5aqEBPnDv9d77+NDxfjROtywxzNdAVNyaOr+RsLhM28Ts+Ar7luIp/Q+SBYa6wv/7BBcOpEkrhtDxsl2WA9Jg==",
       "dev": true
+    },
+    "socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "requires": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      }
     },
     "sort-keys": {
       "version": "1.1.2",
@@ -18195,6 +21240,23 @@
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
+    "speed-limiter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/speed-limiter/-/speed-limiter-1.0.2.tgz",
+      "integrity": "sha512-Ax+TbUOho84bWUc3AKqWtkIvAIVws7d6QI4oJkgH4yQ5Yil+lR3vjd/7qd51dHKGzS5bFxg0++QwyNRN7s6rZA==",
+      "requires": {
+        "limiter": "^1.1.5",
+        "streamx": "^2.10.3"
+      }
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -18213,11 +21275,20 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "requires": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -18225,8 +21296,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -18273,6 +21343,22 @@
         "es-abstract": "^1.20.4"
       }
     },
+    "string2compact": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/string2compact/-/string2compact-2.0.2.tgz",
+      "integrity": "sha512-ZUUIyrS+sSj84gR6fFoz/boiqCptyw37/hMxIehReuf6ekpJOlwSXhTfEasqc5t3QucBXi2ghwLlHOSC8hjEaw==",
+      "requires": {
+        "addr-to-ip-port": "^2.0.0",
+        "ipaddr.js": "2.0.1"
+      },
+      "dependencies": {
+        "ipaddr.js": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+          "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
+        }
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -18286,6 +21372,11 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
+    },
+    "strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
     },
     "strip-indent": {
       "version": "4.0.0",
@@ -18345,6 +21436,56 @@
           "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
           "dev": true
         }
+      }
+    },
+    "tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "requires": {
+        "streamx": "^2.12.5"
       }
     },
     "temp": {
@@ -18429,11 +21570,40 @@
         }
       }
     },
+    "text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "requires": {
+        "b4a": "^1.6.4"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "throughput": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/throughput/-/throughput-1.0.2.tgz",
+      "integrity": "sha512-jvK1ZXuhsggjb3qYQjMiU/AVYYiTeqT5thWvYR2yuy2LGM84P5MSSyAinwHahGsdBYKR9m9HncVR/3f3nFKkxg=="
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "timeout-refresh": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/timeout-refresh/-/timeout-refresh-1.0.3.tgz",
+      "integrity": "sha512-Mz0CX4vBGM5lj8ttbIFt7o4ZMxk/9rgudJRh76EvB7xXZMur7T/cjRiH2w4Fmkq0zxf2QpM8IFvOSRn8FEu3gA==",
+      "optional": true
     },
     "tiny-async-pool": {
       "version": "1.3.0",
@@ -18511,6 +21681,26 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "torrent-discovery": {
+      "version": "11.0.21",
+      "resolved": "https://registry.npmjs.org/torrent-discovery/-/torrent-discovery-11.0.21.tgz",
+      "integrity": "sha512-x+RGu60qJp2u4S7B7XglyYCrfDJWKB0RIexODlA5dpBpMh94q4MbmRjusdbvxN+XD4NHhpwEfub/CRA9pUXjEQ==",
+      "requires": {
+        "bittorrent-dht": "^11.0.12",
+        "bittorrent-lsd": "^2.0.3",
+        "bittorrent-tracker": "^11.2.3",
+        "debug": "^4.4.3",
+        "run-parallel": "^1.2.0"
+      }
+    },
+    "torrent-piece": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/torrent-piece/-/torrent-piece-4.0.1.tgz",
+      "integrity": "sha512-bL5lLm0CknuXMJ3c8Xw+27etPTH7P1vLXwEASQ3bktZlWV2ZEkCW1l0ssV6Y9EHpcUlf0aqB9x49bkgMA4JrHw==",
+      "requires": {
+        "uint8-util": "^2.1.9"
+      }
+    },
     "trim-newlines": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
@@ -18555,6 +21745,14 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -18589,6 +21787,14 @@
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
+      }
+    },
+    "uint8-util": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/uint8-util/-/uint8-util-2.2.6.tgz",
+      "integrity": "sha512-r+ZjS8CzPhtPF771ROOadUoqC40OVdiMKBI8lTfJQWb4W7+73sMBwMYmai/uvNcmZ7tBJJyZSad03yMWIt3RQg==",
+      "requires": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "unbox-primitive": {
@@ -18648,6 +21854,17 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unordered-array-remove": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unordered-array-remove/-/unordered-array-remove-1.0.2.tgz",
+      "integrity": "sha512-45YsfD6svkgaCBNyvD+dFHm4qFX9g3wRSIVgWVPtm2OCnphvPxzJoe20ATsiNpNJrmzHifnxm+BN5F7gFT/4gw=="
+    },
+    "unordered-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unordered-set/-/unordered-set-2.0.1.tgz",
+      "integrity": "sha512-eUmNTPzdx+q/WvOHW0bgGYLWvWHNT3PTKEQLg0MAQhc0AHASHVHoP/9YytYd4RBVariqno/mEUhVZN98CmD7bg==",
+      "optional": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -18724,6 +21941,36 @@
         "punycode": "^2.1.0"
       }
     },
+    "ut_metadata": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ut_metadata/-/ut_metadata-5.0.1.tgz",
+      "integrity": "sha512-V+6jKXXvkH8YQDFeSpvjSkn7Yiz7Juz3LhIkA1QhxuvOjhrqwlZKJfRMOjVSEW/mPa9Bpk4hvFOCim98tzR04w==",
+      "requires": {
+        "bencode": "^4.0.0",
+        "bitfield": "^5.0.0",
+        "debug": "^4.2.0",
+        "uint8-util": "^2.1.3"
+      }
+    },
+    "ut_pex": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ut_pex/-/ut_pex-5.0.2.tgz",
+      "integrity": "sha512-tPWnEmFIpn47IgZ3CyMzA4onr6zGtBrR+DVtRGoyCpC59OgqELvj9jkzLuisCwIH5FdUQiwqtXtsiAWwpUfrKw==",
+      "requires": {
+        "bencode": "^4.0.1",
+        "compact2string": "^1.4.1",
+        "string2compact": "^2.0.2"
+      }
+    },
+    "utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -18733,13 +21980,38 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+    },
+    "utp-native": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/utp-native/-/utp-native-2.5.3.tgz",
+      "integrity": "sha512-sWTrWYXPhhWJh+cS2baPzhaZc89zwlWCfwSthUjGhLkZztyPhcQllo+XVVCbNGi7dhyRlxkWxN4NKU6FbA9Y8w==",
+      "optional": true,
+      "requires": {
+        "napi-macros": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.0.2",
+        "timeout-refresh": "^1.0.0",
+        "unordered-set": "^2.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -18778,6 +22050,11 @@
         }
       }
     },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
+    },
     "webcrypto-core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
@@ -18791,11 +22068,72 @@
         "tslib": "^2.8.1"
       }
     },
+    "webrtc-polyfill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/webrtc-polyfill/-/webrtc-polyfill-1.2.2.tgz",
+      "integrity": "sha512-t/H2OySa7lZSq2f5j4whmr+IWCl5TqF4daGotE8VhPP7U+E4x5x8MK1wqOkqlb4xxRlag4kBB9enU4oxNk//+g==",
+      "requires": {
+        "node-datachannel": "^0.32.3"
+      }
+    },
+    "webtorrent": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/webtorrent/-/webtorrent-3.0.16.tgz",
+      "integrity": "sha512-oryVor+AGWiNbI4zBT58CKw5MrUYz2GxP5fleHyIhucqwTYAl6pjGkDTjCPGiY5VZCPnVhhhlt+eFov85ZgZKg==",
+      "requires": {
+        "@silentbot1/nat-api": "^0.4.9",
+        "@thaunknown/simple-peer": "^10.1.1",
+        "@webtorrent/http-node": "^1.3.0",
+        "addr-to-ip-port": "^2.0.0",
+        "bitfield": "^5.0.1",
+        "bittorrent-dht": "^11.0.12",
+        "bittorrent-protocol": "^5.0.6",
+        "cache-chunk-store": "^3.2.2",
+        "chunk-store-iterator": "^1.0.4",
+        "cpus": "^1.0.3",
+        "create-torrent": "^6.1.2",
+        "cross-fetch-ponyfill": "^1.0.3",
+        "debug": "^4.4.3",
+        "escape-html": "^1.0.3",
+        "fs-chunk-store": "^5.0.1",
+        "fsa-chunk-store": "^1.3.0",
+        "immediate-chunk-store": "^2.2.0",
+        "join-async-iterator": "^1.1.1",
+        "load-ip-set": "^3.0.2",
+        "lt_donthave": "^2.0.7",
+        "memory-chunk-store": "^1.3.5",
+        "mime": "^3.0.0",
+        "once": "^1.4.0",
+        "parse-torrent": "^11.0.21",
+        "pump": "^3.0.4",
+        "queue-microtask": "^1.2.3",
+        "random-iterate": "^1.0.1",
+        "range-parser": "^1.2.1",
+        "run-parallel": "^1.2.0",
+        "run-parallel-limit": "^1.1.0",
+        "speed-limiter": "^1.0.2",
+        "streamx": "2.25.0",
+        "throughput": "^1.0.2",
+        "torrent-discovery": "^11.0.21",
+        "torrent-piece": "^4.0.1",
+        "uint8-util": "^2.2.6",
+        "unordered-array-remove": "^1.0.2",
+        "ut_metadata": "^5.0.1",
+        "ut_pex": "^5.0.2",
+        "utp-native": "^2.5.3"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
+        }
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -18812,6 +22150,12 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
+    },
+    "which-runtime": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.4.0.tgz",
+      "integrity": "sha512-0ugbP4CJW4e2D20jvEcC4973dCgIaHI4Rw1PT+26U9zEve7FyYdWAIwUnoeOYvoCfn+wXHoHTKb1KhkYlb60Pw==",
+      "optional": true
     },
     "which-typed-array": {
       "version": "1.1.9",
@@ -18847,8 +22191,29 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "requires": {}
+    },
+    "xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        }
+      }
     },
     "xmlbuilder": {
       "version": "15.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4568,6 +4568,13 @@
         "utf-8-validate": "^6.0.4"
       }
     },
+    "node_modules/bittorrent-tracker/node_modules/ip": {
+      "name": "neoip",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/neoip/-/neoip-2.1.0.tgz",
+      "integrity": "sha512-4zQ8eVAmbBNV3Fmpm3Li2tNPnrU6UobMXpO1OZsY/Eg2AGOB+H8dZfAabMVrh7Xl9xAVIDcEIlUVA057Fi7QdA==",
+      "license": "MIT"
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -8219,12 +8226,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -16323,7 +16324,7 @@
         "compact2string": "^1.4.1",
         "cross-fetch-ponyfill": "^1.0.3",
         "debug": "^4.3.4",
-        "ip": "^2.0.1",
+        "ip": "npm:neoip@2.1.0",
         "lru": "^3.1.0",
         "minimist": "^1.2.8",
         "once": "^1.4.0",
@@ -16337,6 +16338,13 @@
         "unordered-array-remove": "^1.0.2",
         "utf-8-validate": "^6.0.4",
         "ws": "^8.17.0"
+      },
+      "dependencies": {
+        "ip": {
+          "version": "npm:neoip@2.1.0",
+          "resolved": "https://registry.npmjs.org/neoip/-/neoip-2.1.0.tgz",
+          "integrity": "sha512-4zQ8eVAmbBNV3Fmpm3Li2tNPnrU6UobMXpO1OZsY/Eg2AGOB+H8dZfAabMVrh7Xl9xAVIDcEIlUVA057Fi7QdA=="
+        }
       }
     },
     "bl": {
@@ -18847,11 +18855,6 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
-    },
-    "ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "ip-address": {
       "version": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kiwix-js-electron",
   "productName": "Kiwix JS Electron",
-  "version": "3.8.7-E",
+  "version": "3.8.6-E",
   "description": "Kiwix JS offline ZIM archive reader packaged for the Electron framework",
   "main": "main.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,7 @@
     "electron-context-menu": "^3.1.1",
     "electron-store": "^8.1.0",
     "electron-updater": "^6.6.8",
-    "express": "^4.22.2"
+    "express": "^4.22.2",
+    "webtorrent": "3.0.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "kiwix-js-electron",
   "productName": "Kiwix JS Electron",
-  "version": "3.8.6-E",
+  "version": "3.8.7-E",
   "description": "Kiwix JS offline ZIM archive reader packaged for the Electron framework",
   "main": "main.cjs",
   "type": "module",
   "build": {
     "appId": "kiwix.js.electron",
+    "npmRebuild": false,
     "productName": "Kiwix JS Electron",
     "directories": {
       "output": "bld/Electron",
@@ -138,6 +139,7 @@
       "www/**",
       "preload.cjs",
       "main.cjs",
+      "torrentDownloader.cjs",
       "!**/*.dev.{js,wasm}"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -206,6 +206,9 @@
     "rollup-plugin-copy": "^3.4.0",
     "vite": "^8.0.16"
   },
+  "overrides": {
+    "ip": "npm:neoip@2.1.0"
+  },
   "dependencies": {
     "@types/fs-extra": "^9.0.11",
     "core-js": "3.30.2",

--- a/package.json.nwjs
+++ b/package.json.nwjs
@@ -13,9 +13,9 @@
     "icon": "www/img/icons/kiwix-256.png"
   },
   "scripts": {
-    "start": "run --x86 --mirror https://dl.nwjs.io/ .",
-    "dist-win-x86": "build --tasks win-x86 --mirror https://dl.nwjs.io/ .",
-    "dist-win-x64": "build --tasks win-x64 --mirror https://dl.nwjs.io/ .",
+    "start": "run --x86 --mirror https://dl.nwjs.io .",
+    "dist-win-x86": "build --tasks win-x86 --mirror https://dl.nwjs.io .",
+    "dist-win-x64": "build --tasks win-x64 --mirror https://dl.nwjs.io .",
     "dist": "@powershell -NoProfile -ExecutionPolicy Unrestricted -Command ./scripts/Build-NWJS.ps1"
   },
   "build-xp": {
@@ -92,6 +92,8 @@
     "nwjs-builder-phoenix": "^1.15.0"
   },
   "dependencies": {
-    "@types/fs-extra": "^9.0.11"
+    "@fortawesome/fontawesome-free": "^5.15.4",
+    "@types/fs-extra": "^9.0.11",
+    "bootstrap": "^4.6.2"
   }
 }

--- a/preload.cjs
+++ b/preload.cjs
@@ -65,6 +65,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getExternalAccessState: function () {
         return ipcRenderer.invoke('get-external-access-state');
     },
+    // In-app BitTorrent needs WebTorrent 3.x (Node 20+) and the native node-datachannel WebRTC
+    // addon, which ships no 32-bit (ia32) prebuild. Older Electron builds — the 18.3.15 pinned
+    // for 32-bit Linux, and the legacy Electron used for Windows 7 — bundle Node < 20, and 32-bit
+    // builds lack the native module, so the feature is unavailable there. The renderer gates on
+    // this flag (see torrentClient.js) so those builds never offer a download that would fail.
+    torrentSupported: parseInt(process.versions.node, 10) >= 20 && process.arch !== 'ia32',
     // In-app BitTorrent download API (implemented in torrentDownloader.cjs, wired in main.cjs);
     // progress/completion events arrive via the generic 'on' listener below, on the channels
     // 'torrent-progress', 'torrent-done' and 'torrent-error'

--- a/preload.cjs
+++ b/preload.cjs
@@ -65,6 +65,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getExternalAccessState: function () {
         return ipcRenderer.invoke('get-external-access-state');
     },
+    // In-app BitTorrent download API (implemented in torrentDownloader.cjs, wired in main.cjs);
+    // progress/completion events arrive via the generic 'on' listener below, on the channels
+    // 'torrent-progress', 'torrent-done' and 'torrent-error'
+    startTorrentDownload: function (args) {
+        return ipcRenderer.invoke('torrent-start', args);
+    },
+    stopTorrentDownload: function (infoHash, deletePartial) {
+        return ipcRenderer.invoke('torrent-stop', infoHash, deletePartial);
+    },
+    getTorrentStatus: function (infoHash) {
+        return ipcRenderer.invoke('torrent-status', infoHash);
+    },
+    setTorrentSeeding: function (value) {
+        ipcRenderer.send('torrent-set-seeding', value);
+    },
     isMicrosoftStoreApp: process.windowsStore && regexpInstalledFromMicrosoftStore.test(__dirname),
     isAppxOrMSIX: isAppxOrMSIX(),
     __dirname: __dirname,

--- a/preload.cjs
+++ b/preload.cjs
@@ -80,6 +80,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     setTorrentSeeding: function (value) {
         ipcRenderer.send('torrent-set-seeding', value);
     },
+    deletePartialTorrentFile: function (savePath, name) {
+        return ipcRenderer.invoke('torrent-delete-partial', savePath, name);
+    },
     isMicrosoftStoreApp: process.windowsStore && regexpInstalledFromMicrosoftStore.test(__dirname),
     isAppxOrMSIX: isAppxOrMSIX(),
     __dirname: __dirname,

--- a/scripts/afterPack.cjs
+++ b/scripts/afterPack.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+/**
+ * scripts/afterPack.cjs — electron-builder afterPack hook for the Windows nsis-web build.
+ *
+ * WHY THIS EXISTS
+ * The Windows nsis-web installer is built in a single `--ia32 --x64 --arm64` pass, and it has to
+ * be: the Web Setup .exe detects the host arch at install time and downloads the matching package,
+ * so the three arch packages must be produced together (they cannot be split into per-arch build
+ * steps the way macOS and Linux are). Because package.json sets `npmRebuild: false`, electron-builder
+ * copies the ONE node-datachannel binary that npm installed on the x64 CI runner into every arch's
+ * package — leaving the arm64 package with an x64 WebRTC addon that fails to load on Windows on ARM.
+ * macOS/Linux dodge this by building each arch in its own workflow step and swapping the prebuild in
+ * between; nsis-web can't, so we correct each arch here, where the hook fires once per arch with the
+ * packed output dir (context.appOutDir), before the package is compressed into its .nsis.7z.
+ *
+ * WHAT IT DOES (Windows only — macOS/Linux keep their per-step swaps and return early here)
+ * - ia32: no node-datachannel prebuild exists and the torrent feature is gated off on ia32 (see
+ *   preload.cjs `torrentSupported`), so the wrong-arch binary is deleted rather than shipped dead.
+ * - x64 / arm64: downloads node-datachannel's win32-<arch> N-API prebuild (a download, no compile)
+ *   and overwrites the packed binary, then reads its PE machine type and throws on any mismatch, so
+ *   a wrong-arch package can never be published — our CI arch-check, since Windows on ARM cannot be
+ *   tested on-device here.
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { Arch } = require('electron-builder');
+
+// Location of the auto-unpacked native addon inside a packed app. electron-builder unpacks .node
+// modules out of the asar automatically; this is the same path that appeared in the macOS runtime
+// dlopen error when the wrong-arch binary was shipped.
+const REL_BINARY = path.join('resources', 'app.asar.unpacked', 'node_modules',
+    'node-datachannel', 'build', 'Release', 'node_datachannel.node');
+
+// PE (Windows executable) machine-type identifiers, read from the COFF header of the binary.
+const PE_MACHINE = { ia32: 0x014c, x64: 0x8664, arm64: 0xaa64 };
+
+/**
+ * Reads the machine type from a Windows PE binary: the 2-byte COFF Machine field immediately after
+ * the "PE\0\0" signature, whose file offset is stored as a 4-byte little-endian value at 0x3C.
+ * @param {String} file Path to the .node/.dll/.exe binary
+ * @returns {Number} The IMAGE_FILE_MACHINE_* value
+ */
+function readPeMachine (file) {
+    const fd = fs.openSync(file, 'r');
+    try {
+        const head = Buffer.alloc(4);
+        fs.readSync(fd, head, 0, 4, 0x3c);
+        const peOffset = head.readUInt32LE(0);
+        const machine = Buffer.alloc(2);
+        fs.readSync(fd, machine, 0, 2, peOffset + 4);
+        return machine.readUInt16LE(0);
+    } finally {
+        fs.closeSync(fd);
+    }
+}
+
+exports.default = async function afterPack (context) {
+    // Only the Windows multi-arch nsis-web build needs per-arch correction here.
+    if (context.electronPlatformName !== 'win32') return;
+
+    const arch = Arch[context.arch]; // 'ia32' | 'x64' | 'arm64'
+    const packed = path.join(context.appOutDir, REL_BINARY);
+
+    // The module may be absent — e.g. the legacy Win7 build strips webtorrent before install, so
+    // there is no node-datachannel binary to fix.
+    if (!fs.existsSync(packed)) return;
+
+    if (arch === 'ia32') {
+        fs.rmSync(packed, { force: true });
+        console.log('[afterPack] removed node-datachannel from the ia32 package (no prebuild; feature gated off)');
+        return;
+    }
+
+    const ndcDir = path.join(context.packager.projectDir, 'node_modules', 'node-datachannel');
+    const prebuildInstall = require.resolve('prebuild-install/bin.js', { paths: [ndcDir] });
+    console.log('[afterPack] downloading node-datachannel win32-' + arch + ' prebuild...');
+    // prebuild-install must run as a child process (it calls process.exit); cwd must be the
+    // node-datachannel dir so it reads that package's manifest and writes to its build/Release.
+    execFileSync(process.execPath,
+        [prebuildInstall, '-r', 'napi', '--arch', arch, '--platform', 'win32'],
+        { cwd: ndcDir, stdio: 'inherit' });
+    fs.copyFileSync(path.join(ndcDir, 'build', 'Release', 'node_datachannel.node'), packed);
+
+    // CI arch-check: prove the packed binary really is the target arch, or fail the build.
+    const machine = readPeMachine(packed);
+    if (machine !== PE_MACHINE[arch]) {
+        throw new Error('[afterPack] node_datachannel.node for ' + arch + ' has PE machine 0x' +
+            machine.toString(16) + ', expected 0x' + PE_MACHINE[arch].toString(16));
+    }
+    console.log('[afterPack] verified node_datachannel.node is win32-' + arch +
+        ' (PE machine 0x' + machine.toString(16) + ')');
+};

--- a/scripts/electronBuilder-signed.cjs
+++ b/scripts/electronBuilder-signed.cjs
@@ -1,0 +1,13 @@
+const fs = require('fs');
+
+// Signed Windows builds normally read their electron-builder config straight from dist/package.json's
+// `build` field (unlike the unsigned path, which uses electronBuilder.cjs to strip signing). A JSON
+// config can't carry a function hook, so this thin JS config re-exports that same build config
+// UNCHANGED — signing config intact — with only the per-arch afterPack hook added, so the signed
+// nsis-web arm64 package gets the correct-arch node-datachannel binary too (see afterPack.cjs).
+const baseConfig = JSON.parse(fs.readFileSync('dist/package.json', 'utf8')).build;
+
+module.exports = {
+    ...baseConfig,
+    afterPack: require('./afterPack.cjs').default
+};

--- a/scripts/electronBuilder.cjs
+++ b/scripts/electronBuilder.cjs
@@ -13,7 +13,10 @@ const unsignedConfig = {
     },
     // Remove top-level configs related to signing
     cscLink: undefined,
-    cscKeyPassword: undefined
+    cscKeyPassword: undefined,
+    // Per-arch fix for the Windows nsis-web build's native node-datachannel binary (see
+    // afterPack.cjs). A no-op on non-Windows targets and where the module isn't packaged.
+    afterPack: require('./afterPack.cjs').default
 };
 
 // Remove properties if they exist

--- a/service-worker.js
+++ b/service-worker.js
@@ -206,6 +206,7 @@ const precacheFiles = [
     'www/js/lib/popovers.js',
     'www/js/lib/resetApp.js',
     'www/js/lib/settingsStore.js',
+    'www/js/lib/torrentClient.js',
     'www/js/lib/transformStyles.js',
     'www/js/lib/transformZimit.js',
     'www/js/lib/uiUtil.js',

--- a/torrentDownloader.cjs
+++ b/torrentDownloader.cjs
@@ -7,13 +7,50 @@
 
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+
 let WebTorrent = null; // Lazily imported WebTorrent constructor
+let TolerantStore = null; // Chunk-store class that fixes downloads to a drive root (see getClient)
 let client = null; // Singleton WebTorrent client (created on first download)
 let keepSeeding = true; // Whether to go on seeding a completed torrent until the app quits
 const downloads = new Map(); // infoHash -> { torrent, progressTimer, callbacks, torrentUrl }
 
 // Interval in ms between progress reports to the caller
 const PROGRESS_INTERVAL = 1000;
+
+let mkdirPatched = false;
+
+/**
+ * Corrects the callback form of fs.mkdir for Windows drive roots: Node's recursive mkdir
+ * wrongly reports EPERM on a drive root such as 'W:\' even though the directory exists
+ * (long-standing Node issue), and WebTorrent's storage layer (fs-chunk-store and
+ * random-access-file) recursively mkdirs the containing directory of every download, so
+ * saving an archive directly to the root of a drive always failed. The wrapper only
+ * intervenes when a recursive call errors with EPERM/EACCES and the target does in fact
+ * exist as a directory (i.e. cases where the documented behaviour is success); every other
+ * call and error path is passed through unchanged.
+ */
+function patchMkdirForDriveRoots () {
+    if (mkdirPatched) return;
+    mkdirPatched = true;
+    const realMkdir = fs.mkdir;
+    fs.mkdir = function (target, options, callback) {
+        if (typeof options === 'function' || !(options && options.recursive)) {
+            return realMkdir.apply(fs, arguments);
+        }
+        return realMkdir.call(fs, target, options, function (err) {
+            const args = arguments;
+            if (err && (err.code === 'EPERM' || err.code === 'EACCES')) {
+                return fs.stat(target, function (statErr, stats) {
+                    if (!statErr && stats.isDirectory()) return callback(null);
+                    callback(err);
+                });
+            }
+            callback.apply(null, args);
+        });
+    };
+}
 
 /**
  * Lazily imports WebTorrent and creates the singleton client
@@ -26,7 +63,48 @@ async function getClient () {
         throw new Error('In-app BitTorrent downloads require Node 20+, but this runtime has Node ' + process.versions.node);
     }
     if (!WebTorrent) {
+        // Apply the drive-root mkdir correction before WebTorrent (and its storage
+        // dependencies) are loaded, so that all of them see the corrected behaviour
+        patchMkdirForDriveRoots();
         WebTorrent = (await import('webtorrent')).default;
+        // fs-chunk-store and random-access-file are webtorrent's own dependencies (kept in step
+        // with it by the lockfile); we need them to build a store that can save to a drive root
+        const FSChunkStore = (await import('fs-chunk-store')).default;
+        const RAF = (await import('random-access-file')).default;
+        // DEV: fs-chunk-store unconditionally does a recursive mkdir of the directory containing
+        // each file, but Node's recursive mkdir throws EPERM (instead of reporting success) on a
+        // Windows drive root such as 'W:\', even though it exists (nodejs/node issue). This
+        // subclass re-wraps each file's open function with one that tolerates a failed mkdir
+        // whenever the directory does in fact exist, so that archives can be downloaded directly
+        // to the root of a drive.
+        TolerantStore = class extends FSChunkStore {
+            constructor (chunkLength, opts) {
+                super(chunkLength, opts);
+                const self = this;
+                this.files.forEach(function (file) {
+                    let opened = null; // Memoized result; reset on failure so a retry is possible
+                    file.open = function (cb) {
+                        if (!opened) {
+                            opened = new Promise(function (resolve, reject) {
+                                if (self.closed) return reject(new Error('Storage is closed'));
+                                const dir = path.dirname(file.path);
+                                fs.promises.mkdir(dir, { recursive: true }).catch(function (err) {
+                                    // Ignore the error if the directory already exists
+                                    return fs.promises.stat(dir).then(function (stats) {
+                                        if (!stats.isDirectory()) throw err;
+                                    }, function () { throw err; });
+                                }).then(function () {
+                                    if (self.closed) throw new Error('Storage is closed');
+                                    resolve(new RAF(file.path));
+                                }).catch(reject);
+                            });
+                            opened.catch(function () { opened = null; });
+                        }
+                        opened.then(function (raf) { cb(null, raf); }, function (err) { cb(err); });
+                    };
+                });
+            }
+        };
     }
     // Incoming peer connections are accepted (default), for better connectivity and effective
     // seeding: note that this causes a one-time firewall prompt on Windows
@@ -77,6 +155,16 @@ async function startDownload (args, callbacks) {
             throw new Error('This torrent is already being downloaded');
         }
     }
+    // Check that the download folder exists before we start (clearer error than the store's)
+    let savePathStats = null;
+    try {
+        savePathStats = await fs.promises.stat(args.savePath);
+    } catch (err) {
+        throw new Error('The download folder does not exist or cannot be accessed: ' + args.savePath);
+    }
+    if (!savePathStats.isDirectory()) {
+        throw new Error('The download location is not a folder: ' + args.savePath);
+    }
     const cl = await getClient();
     const response = await fetch(args.torrentUrl);
     if (!response.ok) {
@@ -85,7 +173,7 @@ async function startDownload (args, callbacks) {
     const torrentBuffer = Buffer.from(await response.arrayBuffer());
     return new Promise(function (resolve, reject) {
         let settled = false;
-        const torrent = cl.add(torrentBuffer, { path: args.savePath });
+        const torrent = cl.add(torrentBuffer, { path: args.savePath, store: TolerantStore });
         torrent.on('error', function (err) {
             console.error('[torrentDownloader] Torrent error: ' + (err.message || err));
             removeRecord(torrent.infoHash);

--- a/torrentDownloader.cjs
+++ b/torrentDownloader.cjs
@@ -348,6 +348,30 @@ async function startDownload (args, callbacks) {
 }
 
 /**
+ * Deletes an abandoned partial (or completed) download from disk by its save path and name,
+ * without needing to add the torrent back to the client first: this is used to discard a
+ * download that was left in progress when the app was previously closed, so no WebTorrent
+ * instance for it exists in this session yet. ZIM archives are always single-file torrents, so
+ * the on-disk data is a single file directly inside savePath, named after the torrent.
+ * @param {String} savePath The directory the torrent was downloading into
+ * @param {String} name The torrent's name (i.e. the downloaded file's name)
+ * @returns {Promise<Boolean>} A Promise resolving true if a file was found and deleted, or
+ *   false if there was nothing to delete
+ */
+async function deletePartialFile (savePath, name) {
+    if (!savePath || !name) return false;
+    const target = path.join(savePath, name);
+    try {
+        await fs.promises.unlink(target);
+        console.log('[torrentDownloader] Deleted discarded partial download: ' + target);
+        return true;
+    } catch (err) {
+        if (err.code === 'ENOENT') return false;
+        throw err;
+    }
+}
+
+/**
  * Clears the progress timer for a download and forgets it
  * @param {String} infoHash The infoHash of the torrent to forget
  */
@@ -432,6 +456,7 @@ function destroyAll () {
 module.exports = {
     startDownload: startDownload,
     stopTorrent: stopTorrent,
+    deletePartialFile: deletePartialFile,
     getStatus: getStatus,
     setKeepSeeding: setKeepSeeding,
     destroyAll: destroyAll

--- a/torrentDownloader.cjs
+++ b/torrentDownloader.cjs
@@ -1,0 +1,216 @@
+// torrentDownloader.cjs: In-app BitTorrent downloader for ZIM archives.
+// This module is shared between the Electron main process (via require from main.cjs) and,
+// in future, the NWJS Node context. It must therefore remain CommonJS and framework-agnostic:
+// all Electron- or NWJS-specific wiring (IPC, events) belongs in the caller.
+// WebTorrent v3+ is an ES Module requiring Node 20+, so it is lazily imported on first use;
+// runtimes with older Node (e.g. NWJS 0.14.7 for XP/Vista) must not call into this module.
+
+'use strict';
+
+let WebTorrent = null; // Lazily imported WebTorrent constructor
+let client = null; // Singleton WebTorrent client (created on first download)
+let keepSeeding = true; // Whether to go on seeding a completed torrent until the app quits
+const downloads = new Map(); // infoHash -> { torrent, progressTimer, callbacks, torrentUrl }
+
+// Interval in ms between progress reports to the caller
+const PROGRESS_INTERVAL = 1000;
+
+/**
+ * Lazily imports WebTorrent and creates the singleton client
+ * @returns {Promise<Object>} A Promise for the WebTorrent client
+ */
+async function getClient () {
+    if (client) return client;
+    const nodeMajor = parseInt(process.versions.node, 10);
+    if (nodeMajor < 20) {
+        throw new Error('In-app BitTorrent downloads require Node 20+, but this runtime has Node ' + process.versions.node);
+    }
+    if (!WebTorrent) {
+        WebTorrent = (await import('webtorrent')).default;
+    }
+    // Incoming peer connections are accepted (default), for better connectivity and effective
+    // seeding: note that this causes a one-time firewall prompt on Windows
+    client = new WebTorrent();
+    client.on('error', function (err) {
+        console.error('[torrentDownloader] Client error: ' + (err.message || err));
+    });
+    return client;
+}
+
+/**
+ * Builds a plain serializable status object for a torrent (safe to send over IPC)
+ * @param {Object} torrent The WebTorrent torrent object
+ * @returns {Object} The status of the torrent
+ */
+function makeStatus (torrent) {
+    return {
+        infoHash: torrent.infoHash,
+        name: torrent.name,
+        received: torrent.downloaded,
+        total: torrent.length,
+        progress: torrent.progress,
+        downloadSpeed: torrent.downloadSpeed,
+        uploadSpeed: torrent.uploadSpeed,
+        uploaded: torrent.uploaded,
+        numPeers: torrent.numPeers,
+        done: torrent.done,
+        seeding: !!(torrent.done && !torrent.destroyed)
+    };
+}
+
+/**
+ * Starts (or resumes) a torrent download. If a partial file from a previous attempt exists in
+ * savePath, WebTorrent verifies the pieces already on disk and resumes from where it left off.
+ * @param {Object} args An object with keys torrentUrl (URL of the .torrent file, which for Kiwix
+ *   archives includes both trackers and mirror web seeds) and savePath (absolute directory path
+ *   into which the archive will be saved under its torrent name)
+ * @param {Object} callbacks An object with optional keys onProgress, onDone, onError; each
+ *   receives a status object (onError receives an Error). onProgress fires about once a second,
+ *   including while seeding after completion.
+ * @returns {Promise<Object>} A Promise for the initial status of the added torrent
+ */
+async function startDownload (args, callbacks) {
+    callbacks = callbacks || {};
+    // Prevent a duplicate add of a torrent that is already in progress
+    for (const record of downloads.values()) {
+        if (record.torrentUrl === args.torrentUrl) {
+            throw new Error('This torrent is already being downloaded');
+        }
+    }
+    const cl = await getClient();
+    const response = await fetch(args.torrentUrl);
+    if (!response.ok) {
+        throw new Error('Could not fetch torrent file (HTTP ' + response.status + ') from ' + args.torrentUrl);
+    }
+    const torrentBuffer = Buffer.from(await response.arrayBuffer());
+    return new Promise(function (resolve, reject) {
+        let settled = false;
+        const torrent = cl.add(torrentBuffer, { path: args.savePath });
+        torrent.on('error', function (err) {
+            console.error('[torrentDownloader] Torrent error: ' + (err.message || err));
+            removeRecord(torrent.infoHash);
+            if (!settled) {
+                settled = true;
+                reject(err instanceof Error ? err : new Error(String(err)));
+            } else if (callbacks.onError) {
+                callbacks.onError(err instanceof Error ? err : new Error(String(err)));
+            }
+        });
+        torrent.on('ready', function () {
+            const record = {
+                torrent: torrent,
+                torrentUrl: args.torrentUrl,
+                callbacks: callbacks,
+                progressTimer: setInterval(function () {
+                    if (callbacks.onProgress) callbacks.onProgress(makeStatus(torrent));
+                }, PROGRESS_INTERVAL)
+            };
+            downloads.set(torrent.infoHash, record);
+            console.log('[torrentDownloader] Added torrent ' + torrent.name + ' (' + torrent.infoHash + '), saving to ' + args.savePath);
+            if (!settled) {
+                settled = true;
+                resolve(makeStatus(torrent));
+            }
+        });
+        torrent.on('done', function () {
+            console.log('[torrentDownloader] Download complete: ' + torrent.name);
+            const status = makeStatus(torrent);
+            if (!keepSeeding) {
+                // Destroy the torrent but keep the completed file on disk
+                stopTorrent(torrent.infoHash, false);
+                status.seeding = false;
+            }
+            if (callbacks.onDone) callbacks.onDone(status);
+        });
+    });
+}
+
+/**
+ * Clears the progress timer for a download and forgets it
+ * @param {String} infoHash The infoHash of the torrent to forget
+ */
+function removeRecord (infoHash) {
+    const record = downloads.get(infoHash);
+    if (record) {
+        clearInterval(record.progressTimer);
+        downloads.delete(infoHash);
+    }
+}
+
+/**
+ * Stops a torrent (cancels a download in progress, or stops seeding a completed one)
+ * @param {String} infoHash The infoHash of the torrent to stop
+ * @param {Boolean} deletePartial Whether to delete the (partial) file from disk as well:
+ *   pass false to keep it, so that a future download of the same torrent resumes from it
+ * @returns {Promise<Boolean>} A Promise that resolves true if a torrent was found and stopped
+ */
+function stopTorrent (infoHash, deletePartial) {
+    const record = downloads.get(infoHash);
+    if (!record) return Promise.resolve(false);
+    removeRecord(infoHash);
+    return new Promise(function (resolve) {
+        record.torrent.destroy({ destroyStore: !!deletePartial }, function () {
+            console.log('[torrentDownloader] Stopped torrent ' + infoHash + (deletePartial ? ' and deleted its data' : ''));
+            resolve(true);
+        });
+    });
+}
+
+/**
+ * Gets the status of one download, or of all downloads if no infoHash is given
+ * @param {String} infoHash Optional infoHash of a specific torrent
+ * @returns {Object|Array|null} A status object (or null if not found), or an array of statuses
+ */
+function getStatus (infoHash) {
+    if (infoHash) {
+        const record = downloads.get(infoHash);
+        return record ? makeStatus(record.torrent) : null;
+    }
+    const statuses = [];
+    downloads.forEach(function (record) {
+        statuses.push(makeStatus(record.torrent));
+    });
+    return statuses;
+}
+
+/**
+ * Sets whether completed torrents go on seeding until app quit; turning this off stops
+ * any torrent that is currently seeding (downloads in progress are unaffected)
+ * @param {Boolean} value Whether to keep seeding completed torrents
+ */
+function setKeepSeeding (value) {
+    keepSeeding = !!value;
+    if (!keepSeeding) {
+        downloads.forEach(function (record, infoHash) {
+            if (record.torrent.done) stopTorrent(infoHash, false);
+        });
+    }
+}
+
+/**
+ * Destroys the client and all torrents (partial files are kept for later resume);
+ * call this when the app is quitting
+ * @returns {Promise<void>} A Promise that resolves when the client has been destroyed
+ */
+function destroyAll () {
+    downloads.forEach(function (record) {
+        clearInterval(record.progressTimer);
+    });
+    downloads.clear();
+    if (!client) return Promise.resolve();
+    const cl = client;
+    client = null;
+    return new Promise(function (resolve) {
+        cl.destroy(function () {
+            resolve();
+        });
+    });
+}
+
+module.exports = {
+    startDownload: startDownload,
+    stopTorrent: stopTorrent,
+    getStatus: getStatus,
+    setKeepSeeding: setKeepSeeding,
+    destroyAll: destroyAll
+};

--- a/torrentDownloader.cjs
+++ b/torrentDownloader.cjs
@@ -110,7 +110,10 @@ async function getClient () {
     // seeding: note that this causes a one-time firewall prompt on Windows
     client = new WebTorrent();
     client.on('error', function (err) {
+        // Client-level errors are frequently benign on Windows (e.g. a UDP operation refused
+        // by the firewall); they do not stop the torrents, so we log rather than surface them
         console.error('[torrentDownloader] Client error: ' + (err.message || err));
+        if (err && err.stack) console.error(err.stack);
     });
     return client;
 }

--- a/torrentDownloader.cjs
+++ b/torrentDownloader.cjs
@@ -124,6 +124,7 @@ async function getClient () {
  * @returns {Object} The status of the torrent
  */
 function makeStatus (torrent) {
+    const record = downloads.get(torrent.infoHash);
     return {
         infoHash: torrent.infoHash,
         name: torrent.name,
@@ -135,8 +136,30 @@ function makeStatus (torrent) {
         uploaded: torrent.uploaded,
         numPeers: torrent.numPeers,
         done: torrent.done,
-        seeding: !!(torrent.done && !torrent.destroyed)
+        verifying: !!(record && record.verifying),
+        seeding: !!(torrent.done && !torrent.destroyed && !(record && record.verifying))
     };
+}
+
+/**
+ * Checks whether the drive containing savePath has enough free space for the part of the
+ * torrent that remains to be downloaded (bytes already on disk and verified need no new space)
+ * @param {Object} torrent The torrent, which must be ready (so that progress reflects any
+ *   existing data on disk that has been verified)
+ * @param {String} savePath The directory the torrent is downloading into
+ * @returns {Promise<Number>} A Promise for the shortfall in bytes (zero or negative if there
+ *   is enough space, or if free space cannot be determined on this platform)
+ */
+function checkFreeSpace (torrent, savePath) {
+    if (!fs.promises.statfs) return Promise.resolve(0);
+    return fs.promises.statfs(savePath).then(function (stats) {
+        const free = stats.bsize * stats.bavail;
+        const needed = Math.round(torrent.length * (1 - torrent.progress));
+        return needed - free;
+    }, function () {
+        // If free space cannot be determined, do not block the download
+        return 0;
+    });
 }
 
 /**
@@ -152,10 +175,17 @@ function makeStatus (torrent) {
  */
 async function startDownload (args, callbacks) {
     callbacks = callbacks || {};
-    // Prevent a duplicate add of a torrent that is already in progress
-    for (const record of downloads.values()) {
+    // If the same torrent has already finished downloading and is merely seeding, stop it
+    // (keeping the file) so that the fresh add below hash-checks the file on disk and repairs
+    // it if needed; a torrent that is still downloading or verifying is a genuine duplicate
+    for (const [infoHash, record] of downloads) {
         if (record.torrentUrl === args.torrentUrl) {
-            throw new Error('This torrent is already being downloaded');
+            if (record.torrent.done && !record.verifying) {
+                await stopTorrent(infoHash, false);
+            } else {
+                throw new Error('This torrent is already being downloaded');
+            }
+            break;
         }
     }
     // Check that the download folder exists before we start (clearer error than the store's)
@@ -176,43 +206,94 @@ async function startDownload (args, callbacks) {
     const torrentBuffer = Buffer.from(await response.arrayBuffer());
     return new Promise(function (resolve, reject) {
         let settled = false;
-        const torrent = cl.add(torrentBuffer, { path: args.savePath, store: TolerantStore });
-        torrent.on('error', function (err) {
-            console.error('[torrentDownloader] Torrent error: ' + (err.message || err));
-            removeRecord(torrent.infoHash);
-            if (!settled) {
-                settled = true;
-                reject(err instanceof Error ? err : new Error(String(err)));
-            } else if (callbacks.onError) {
-                callbacks.onError(err instanceof Error ? err : new Error(String(err)));
-            }
-        });
-        torrent.on('ready', function () {
-            const record = {
-                torrent: torrent,
-                torrentUrl: args.torrentUrl,
-                callbacks: callbacks,
-                progressTimer: setInterval(function () {
-                    if (callbacks.onProgress) callbacks.onProgress(makeStatus(torrent));
-                }, PROGRESS_INTERVAL)
-            };
-            downloads.set(torrent.infoHash, record);
-            console.log('[torrentDownloader] Added torrent ' + torrent.name + ' (' + torrent.infoHash + '), saving to ' + args.savePath);
-            if (!settled) {
-                settled = true;
-                resolve(makeStatus(torrent));
-            }
-        });
-        torrent.on('done', function () {
-            console.log('[torrentDownloader] Download complete: ' + torrent.name);
-            const status = makeStatus(torrent);
-            if (!keepSeeding) {
-                // Destroy the torrent but keep the completed file on disk
-                stopTorrent(torrent.infoHash, false);
-                status.seeding = false;
-            }
-            if (callbacks.onDone) callbacks.onDone(status);
-        });
+        let record = null;
+        // The torrent is added in up to two phases. The 'download' phase gets the data; on
+        // completion, the torrent is removed (keeping the file) and re-added in a 'verify'
+        // phase, which forces WebTorrent to hash-check the data actually written to disk:
+        // pieces are verified in memory as they are received, but writes are never read back,
+        // so a failing or full disk can corrupt a download without WebTorrent noticing. Any
+        // pieces that fail the check are automatically downloaded again.
+        addTorrent('download');
+        function addTorrent (phase) {
+            const torrent = cl.add(torrentBuffer, { path: args.savePath, store: TolerantStore });
+            // In the verify phase the record already exists: point it at the re-added torrent
+            // straight away, so that progress reports and stop requests track the hash check
+            if (phase === 'verify' && record) record.torrent = torrent;
+            torrent.on('error', function (err) {
+                console.error('[torrentDownloader] Torrent error: ' + (err.message || err));
+                removeRecord(torrent.infoHash);
+                if (!settled) {
+                    settled = true;
+                    reject(err instanceof Error ? err : new Error(String(err)));
+                } else if (callbacks.onError) {
+                    callbacks.onError(err instanceof Error ? err : new Error(String(err)));
+                }
+            });
+            torrent.on('ready', function () {
+                if (phase === 'verify') return;
+                record = {
+                    torrent: torrent,
+                    torrentUrl: args.torrentUrl,
+                    callbacks: callbacks,
+                    verifying: false,
+                    progressTimer: setInterval(function () {
+                        if (callbacks.onProgress && !record.torrent.destroyed) {
+                            callbacks.onProgress(makeStatus(record.torrent));
+                        }
+                    }, PROGRESS_INTERVAL)
+                };
+                downloads.set(torrent.infoHash, record);
+                console.log('[torrentDownloader] Added torrent ' + torrent.name + ' (' + torrent.infoHash + '), saving to ' + args.savePath);
+                // 'ready' fires after any existing on-disk data has been verified, so
+                // torrent.progress now tells us how much remains to be downloaded
+                checkFreeSpace(torrent, args.savePath).then(function (shortfall) {
+                    if (shortfall > 0 && downloads.has(torrent.infoHash)) {
+                        const err = new Error('There is not enough free space on the destination drive: the download needs about ' +
+                            Math.ceil(shortfall / 1048576) + ' MB more than is available. Free up some space and try again.');
+                        console.error('[torrentDownloader] ' + err.message);
+                        stopTorrent(torrent.infoHash, false);
+                        if (!settled) {
+                            settled = true;
+                            reject(err);
+                        } else if (callbacks.onError) {
+                            callbacks.onError(err);
+                        }
+                    } else if (!settled) {
+                        settled = true;
+                        resolve(makeStatus(torrent));
+                    }
+                });
+            });
+            torrent.on('done', function () {
+                const infoHash = torrent.infoHash;
+                const rec = downloads.get(infoHash);
+                if (!rec || rec.torrent !== torrent) return; // Stopped or superseded meanwhile
+                if (phase === 'download' && torrent.downloaded > 0) {
+                    // Data was received in this session, so the file on disk needs checking
+                    // (when nothing was downloaded, everything on disk was already verified
+                    // during the add and a second check would be redundant)
+                    console.log('[torrentDownloader] Download complete; verifying on-disk data: ' + torrent.name);
+                    rec.verifying = true;
+                    torrent.destroy({ destroyStore: false }, function () {
+                        if (!downloads.has(infoHash)) return; // Stopped during the destroy
+                        addTorrent('verify');
+                    });
+                    return;
+                }
+                rec.verifying = false;
+                console.log('[torrentDownloader] Download complete' + (phase === 'verify' ? ' and verified: ' : ': ') + torrent.name);
+                const status = makeStatus(torrent);
+                // Either every piece passed the verify phase's hash check, or (if nothing was
+                // downloaded this session) the whole file was verified when the torrent was added
+                status.verified = true;
+                if (!keepSeeding) {
+                    // Destroy the torrent but keep the completed file on disk
+                    stopTorrent(infoHash, false);
+                    status.seeding = false;
+                }
+                if (callbacks.onDone) callbacks.onDone(status);
+            });
+        }
     });
 }
 

--- a/torrentDownloader.cjs
+++ b/torrentDownloader.cjs
@@ -81,10 +81,29 @@ async function getClient () {
             constructor (chunkLength, opts) {
                 super(chunkLength, opts);
                 const self = this;
+                // When true, file handles are (re)opened without write access: random-access-file
+                // opens files read-write by default, and on Windows an open read-write handle
+                // blocks any other opener that does not grant write sharing - including the app's
+                // own File System Access reads of the completed archive, and tools like
+                // Get-FileHash - so a torrent that is only seeding must hold read-only handles
+                this.readOnly = false;
+                this._handleClosers = [];
                 this.files.forEach(function (file) {
                     let opened = null; // Memoized result; reset on failure so a retry is possible
+                    let openedReadOnly = false; // The access mode of the memoized handle
+                    const closeHandle = function () {
+                        if (!opened) return;
+                        const prev = opened;
+                        opened = null;
+                        // random-access-storage queues the close behind any reads in flight
+                        prev.then(function (raf) { raf.close(function () {}); }, function () {});
+                    };
+                    self._handleClosers.push(closeHandle);
                     file.open = function (cb) {
+                        // If the required access mode has changed, close and reopen the file
+                        if (opened && openedReadOnly !== self.readOnly) closeHandle();
                         if (!opened) {
+                            openedReadOnly = self.readOnly;
                             opened = new Promise(function (resolve, reject) {
                                 if (self.closed) return reject(new Error('Storage is closed'));
                                 const dir = path.dirname(file.path);
@@ -95,7 +114,7 @@ async function getClient () {
                                     }, function () { throw err; });
                                 }).then(function () {
                                     if (self.closed) throw new Error('Storage is closed');
-                                    resolve(new RAF(file.path));
+                                    resolve(new RAF(file.path, { writable: !openedReadOnly }));
                                 }).catch(reject);
                             });
                             opened.catch(function () { opened = null; });
@@ -103,6 +122,14 @@ async function getClient () {
                         opened.then(function (raf) { cb(null, raf); }, function (err) { cb(err); });
                     };
                 });
+            }
+
+            // Closes all open file handles and reopens subsequent access read-only; call this
+            // once the torrent is complete and verified, so that seeding does not keep the
+            // archive locked against readers (see the readOnly comment above)
+            setReadOnly () {
+                this.readOnly = true;
+                this._handleClosers.forEach(function (closeHandle) { closeHandle(); });
             }
         };
     }
@@ -139,6 +166,25 @@ function makeStatus (torrent) {
         verifying: !!(record && record.verifying),
         seeding: !!(torrent.done && !torrent.destroyed && !(record && record.verifying))
     };
+}
+
+/**
+ * Switches a completed torrent's chunk store to read-only file handles. Seeding only ever
+ * reads, but the store's handles were opened read-write for the download, and on Windows an
+ * open read-write handle blocks other openers of the archive (including the app itself
+ * trying to load it); WebTorrent wraps the raw store in caching layers, so this walks down
+ * the .store chain to find the TolerantStore and asks it to reopen its files read-only
+ * @param {Object} torrent The completed torrent whose store should stop holding write access
+ */
+function releaseWriteHandles (torrent) {
+    let store = torrent.store;
+    while (store && store.store && !(TolerantStore && store instanceof TolerantStore)) {
+        store = store.store;
+    }
+    if (TolerantStore && store instanceof TolerantStore) {
+        store.setReadOnly();
+        console.log('[torrentDownloader] Reopened ' + torrent.name + ' read-only for seeding');
+    }
 }
 
 /**
@@ -290,6 +336,10 @@ async function startDownload (args, callbacks) {
                     // Destroy the torrent but keep the completed file on disk
                     stopTorrent(infoHash, false);
                     status.seeding = false;
+                } else {
+                    // Give up write access to the archive so the app (and anything else) can
+                    // open it while it goes on seeding
+                    releaseWriteHandles(torrent);
                 }
                 if (callbacks.onDone) callbacks.onDone(status);
             });

--- a/www/index.html
+++ b/www/index.html
@@ -874,7 +874,7 @@
                     </div>
                     <div id="hideFileSelectors">
                         <div id="chooseArchiveFromLocalStorage" style="display: none;">
-                            <div id="archivesFound" class="row">
+                            <div id="archivesFound" class="row" style="width: 100%;">
                                 <div class="col-12">
                                     <p><span id="archiveNumber">Archives found on this device (tap "Select storage" to rescan)</span>:</p>
                                 </div>

--- a/www/index.html
+++ b/www/index.html
@@ -964,6 +964,13 @@
                                             <b>Allow Internet access?</b> <span id="updateStatus">and <b>check for updates</b></span>
                                         </label>
                                     </div>
+                                    <div id="torrentSettingsDiv" class="row" style="display: none; margin: 0.5em;">
+                                        <label class="checkbox" title="After an in-app BitTorrent download completes, the app can continue to upload (seed) the archive to other users until you close the app. This helps the Kiwix community distribute archives. Turn it off if you are on a metered or slow connection.">
+                                            <input type="checkbox" name="keepTorrentSeeding" id="keepTorrentSeedingCheck" checked>
+                                            <span class="checkmark"></span>
+                                            <b>Keep seeding BitTorrent downloads</b> (<i>until app closes; helps other users</i>)
+                                        </label>
+                                    </div>
                                 </div>
                                 <div id="downloadLinks" style="display: none;"></div>
                                 <pre id="serverResponse" class="card-footer" style="display:none;"></pre>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4767,18 +4767,24 @@ function archiveReadyCallback (archive) {
         params.lastPageHTML = '';
     }
     // If we have dragged and dropped files into an Electron app, we should have access to the path, so we should store it
-    if (appstate.filesDropped && params.storedFilePath) {
-        params.pickedFolder = null;
-        params.pickedFile = params.storedFilePath;
-        settingsStore.setItem('pickedFolder', '', Infinity);
-        settingsStore.setItem('pickedFile', params.pickedFile, Infinity);
-        populateDropDownListOfArchives([params.storedFile], true);
-        settingsStore.setItem('listOfArchives', encodeURI(params.storedFile), Infinity);
-        // We have to remove the file handle to prevent it from launching next time
-        cache.idxDB('delete', 'pickedFSHandle', function () {
-            console.debug('File handle deleted');
-        });
+    if (appstate.filesDropped) {
+        // Always clear the flag on the load that follows the drop: a file dropped without a
+        // path (e.g. one loaded through a File System Access handle) would otherwise leave it
+        // set, and every subsequent archive loaded from the archive list with a path would then
+        // wrongly enter the block below, collapsing the list and voiding the picked folder
         appstate.filesDropped = false;
+        if (params.storedFilePath) {
+            params.pickedFolder = null;
+            params.pickedFile = params.storedFilePath;
+            settingsStore.setItem('pickedFolder', '', Infinity);
+            settingsStore.setItem('pickedFile', params.pickedFile, Infinity);
+            populateDropDownListOfArchives([params.storedFile], true);
+            settingsStore.setItem('listOfArchives', encodeURI(params.storedFile), Infinity);
+            // We have to remove the file handle to prevent it from launching next time
+            cache.idxDB('delete', 'pickedFSHandle', function () {
+                console.debug('File handle deleted');
+            });
+        }
     }
     var reloadLink = document.getElementById('reloadPackagedArchive');
     if (reloadLink) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1226,6 +1226,14 @@ function getNativeFSHandle (callback) {
     }
     console.debug('Getting the last serialized file or folder entry');
     cache.idxDB('pickedFSHandle', function (val) {
+        // Self-heal: if something other than a file system handle was stored (e.g. a path
+        // string), remove it and proceed as if no handle had been stored, or else every app
+        // launch would fail to restore the picked file or folder
+        if (val && typeof val.queryPermission !== 'function') {
+            console.warn('Removing an invalid stored file system handle:', val);
+            cache.idxDB('delete', 'pickedFSHandle', function () {});
+            val = null;
+        }
         if (val) {
             var handle = val;
             return cache.verifyPermission(handle, false).then(function (accessible) {
@@ -1331,6 +1339,12 @@ function selectArchive (list) {
     // If nothing was selected, user will have to click again
     if (!list.target.value) return;
     selectFired = true;
+    // Watchdog: selectFired debounces the duplicate change/click events fired by the list, but
+    // if an archive load fails in a code path that never resets the flag, the list would become
+    // permanently unresponsive, so reset it after ample time for any load to have completed
+    setTimeout(function () {
+        selectFired = false;
+    }, 10000);
     var selected = list.target.value;
     // Void any previous picked file to prevent it launching
     params.storedFile = selected;
@@ -1786,7 +1800,10 @@ document.getElementById('btnRefresh').addEventListener('click', function () {
                 btnArchiveFile.click();
             }
         } else uiUtil.systemAlert('You need to pick a file or folder before you can rescan it!');
-    } else if (window.showOpenFilePicker || params.useOPFS) {
+    } else if ((window.showOpenFilePicker || params.useOPFS) && params.pickedFolder && params.pickedFolder.kind === 'directory') {
+        // Note we check the type of pickedFolder above, not just the API availability, because in
+        // Electron pickedFolder may be a path string (e.g. from the folder dialogue) even though
+        // the File System Access API is available
         processNativeDirHandle(params.pickedFolder);
         if (params.useOPFS) cache.populateOPFSStorageQuota();
     } else if (typeof Windows !== 'undefined') {
@@ -4358,10 +4375,13 @@ function pickFolderNativeFS () {
 function processNativeFileHandle (fileHandle) {
     // console.debug('Processing Native File Handle for: ' + fileHandle.name + ' and storedFile: ' + params.storedFile);
     var handle = fileHandle;
-    // Serialize fileHandle to indexedDB
-    cache.idxDB('pickedFSHandle', fileHandle, function (val) {
-        console.debug('IndexedDB responded with ' + val);
-    });
+    // Serialize fileHandle to indexedDB (only if it is a genuine file system handle: a path
+    // string or other object stored here would break handle restoration on every app launch)
+    if (fileHandle && fileHandle.kind === 'file') {
+        cache.idxDB('pickedFSHandle', fileHandle, function (val) {
+            console.debug('IndexedDB responded with ' + val);
+        });
+    }
     settingsStore.setItem('lastSelectedArchive', fileHandle.name, Infinity);
     params.storedFile = fileHandle.name;
     params.pickedFolder = null;
@@ -4412,10 +4432,14 @@ function pickFolderUWP () { // Support UWP FilePicker [kiwix-js-pwa #3]
 
 function processNativeDirHandle (dirHandle, callback) {
     // console.debug('Processing Native Directory Handle for: ' + dirHandle + ' and storedFile: ' + params.storedFile);
-    // Serialize dirHandle to indexedDB
-    cache.idxDB('pickedFSHandle', dirHandle, function (val) {
-        console.debug('IndexedDB responded with ' + val);
-    });
+    // Serialize dirHandle to indexedDB (only if it is a genuine directory handle: a path
+    // string stored here, e.g. from the Electron folder dialogue, would break handle
+    // restoration on every app launch)
+    if (dirHandle && dirHandle.kind === 'directory') {
+        cache.idxDB('pickedFSHandle', dirHandle, function (val) {
+            console.debug('IndexedDB responded with ' + val);
+        });
+    }
     params.pickedFolder = dirHandle;
     params.pickedFile = '';
     var archiveDisplay = document.getElementById('chooseArchiveFromLocalStorage');

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1470,32 +1470,29 @@ function selectArchive (list) {
         }
         setTimeout(resetUI, 0);
     };
-    // In Electron or NWJS, prefer to load the archive with Node fs methods whenever a real
-    // path to the selected file can be verified: loading through a File System Access handle
-    // is less reliable in these frameworks (Chromium File snapshots can be invalidated on
-    // Windows by concurrent access to the underlying file), and the stored handle can be
-    // stale (e.g. after the download folder was changed with the native folder dialogue,
-    // which returns a path rather than a handle)
-    if (window.fs && !params.useOPFS) {
-        var candidateFolder = typeof params.pickedFolder === 'string' && params.pickedFolder
-            ? params.pickedFolder : settingsStore.getItem('pickedFolder');
-        if (candidateFolder && typeof candidateFolder === 'string') {
-            var folderPath = candidateFolder.replace(/[\\/]+$/, '');
-            // A bare drive letter ('W:') is drive-relative in Node, so ensure a root slash
-            if (/^[A-Za-z]:$/.test(folderPath)) folderPath += '/';
-            window.fs.stat(folderPath.replace(/\/$/, '') + '/' + selected, function (err, stats) {
-                if (!err && stats) {
-                    console.debug('Loading ' + selected + ' with Node fs from verified folder path: ' + folderPath);
-                    params.pickedFolder = folderPath;
-                    setLocalArchiveFromArchiveList(selected);
-                    setTimeout(resetUI, 0);
-                } else {
-                    // The selected archive is not at the candidate path: fall back to handles
-                    selectViaFSHandles();
-                }
-            });
-            return;
-        }
+    // In Electron or NWJS, prefer to load the archive with Node fs methods whenever the current
+    // folder is known by a real path (e.g. it was picked with the native folder dialogue, which
+    // returns a path rather than a handle, or restored from a stored path at launch): loading
+    // through a File System Access handle is less reliable in these frameworks (Chromium File
+    // snapshots can be invalidated on Windows by concurrent access to the underlying file).
+    // DEV: do not substitute a stored path when params.pickedFolder is an FSA handle: the stored
+    // path may point to a different folder containing a same-named (e.g. partially downloaded)
+    // copy of the selected archive, which would then be loaded silently in place of the right one
+    if (window.fs && !params.useOPFS && params.pickedFolder && typeof params.pickedFolder === 'string') {
+        var folderPath = params.pickedFolder.replace(/[\\/]+$/, '');
+        // A bare drive letter ('W:') is drive-relative in Node, so ensure a root slash
+        if (/^[A-Za-z]:$/.test(folderPath)) folderPath += '/';
+        window.fs.stat(folderPath.replace(/\/$/, '') + '/' + selected, function (err, stats) {
+            if (!err && stats) {
+                console.debug('Loading ' + selected + ' with Node fs from verified folder path: ' + folderPath);
+                setLocalArchiveFromArchiveList(selected);
+                setTimeout(resetUI, 0);
+            } else {
+                // The selected archive is not at the known path: fall back to handles
+                selectViaFSHandles();
+            }
+        });
+        return;
     }
     selectViaFSHandles();
 }

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -2286,6 +2286,8 @@ if (torrentClient.isAvailable()) {
         settingsStore.setItem('keepTorrentSeeding', params.keepTorrentSeeding, Infinity);
         // Turning this off also stops any torrent that is currently seeding
         torrentClient.setSeeding(params.keepTorrentSeeding);
+        // ... and clears the now-stale "Seeding ..." status line the stopped torrent left behind
+        if (!params.keepTorrentSeeding) kiwixServe.clearSeedingStatus();
     });
 }
 document.getElementById('tabOpenerCheck').addEventListener('click', function () {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1197,6 +1197,9 @@ document.getElementById('btnConfigure').addEventListener('click', function () {
         document.getElementById('downloadLinks').style.display = 'none';
         document.getElementById('serverResponse').style.display = 'none';
         document.getElementById('myModal').style.display = 'none';
+        // If a completed torrent is still seeding in the background, show its status so the user
+        // can monitor it here (the line above hid it; this restores it only while seeding)
+        kiwixServe.showSeedingStatus();
         refreshAPIStatus();
         // Re-enable top-level scrolling
         scrollbox.style.height = window.innerHeight - document.getElementById('top').getBoundingClientRect().height + 'px';

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -4047,7 +4047,7 @@ function setLocalArchiveFromArchiveList (archive) {
                                 if (appstate.selectedArchive && appstate.selectedArchive.file._files[0].name === selectedFiles[0].name) {
                                     document.getElementById('btnHome').click();
                                 } else {
-                                    setLocalArchiveFromFileList(selectedFiles);
+                                    setLocalArchiveFromFileList(selectedFiles, true);
                                 }
                             }).catch(function (err) {
                                 console.error(err);

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -38,6 +38,7 @@ import settingsStore from './lib/settingsStore.js';
 import transformStyles from './lib/transformStyles.js';
 import transformZimit from './lib/transformZimit.js';
 import kiwixServe from './lib/kiwixServe.js';
+import torrentClient from './lib/torrentClient.js';
 import updater from './lib/updater.js';
 import resetApp from './lib/resetApp.js';
 
@@ -2229,6 +2230,20 @@ document.getElementById('openExternalLinksInNewTabsCheck').addEventListener('cha
     settingsStore.setItem('openExternalLinksInNewTabs', params.openExternalLinksInNewTabs, Infinity);
     params.themeChanged = true;
 });
+// In-app BitTorrent download settings (only shown where the capability exists, i.e. Electron/NWJS)
+if (torrentClient.isAvailable()) {
+    document.getElementById('torrentSettingsDiv').style.display = 'block';
+    var keepTorrentSeedingCheck = document.getElementById('keepTorrentSeedingCheck');
+    keepTorrentSeedingCheck.checked = params.keepTorrentSeeding;
+    // Communicate the stored setting to the torrent backend
+    torrentClient.setSeeding(params.keepTorrentSeeding);
+    keepTorrentSeedingCheck.addEventListener('change', function () {
+        params.keepTorrentSeeding = this.checked;
+        settingsStore.setItem('keepTorrentSeeding', params.keepTorrentSeeding, Infinity);
+        // Turning this off also stops any torrent that is currently seeding
+        torrentClient.setSeeding(params.keepTorrentSeeding);
+    });
+}
 document.getElementById('tabOpenerCheck').addEventListener('click', function () {
     params.windowOpener = this.checked ? 'tab' : false;
     if (!params.windowOpener && !params.noWarning) {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1414,60 +1414,90 @@ function selectArchive (list) {
             return setLocalArchiveFromFileList([params.pickedFile], true);
         }
     }
-    if (window.showOpenFilePicker || params.useOPFS) {
-        return getNativeFSHandle(function (handle) {
-            resetUI();
-            if (!handle) {
-                if (window.fs && params.storedFilePath) {
-                    // Fall back to using the Electron APIs
-                    params.pickedFolder = params.storedFilePath.replace(/[^\\/]+$/, '');
-                    return setLocalArchiveFromArchiveList(selected);
-                }
-                console.error('No handle was retrieved');
-                document.getElementById('openLocalFiles').style.display = 'block';
-                document.getElementById('rescanStorage').style.display = 'none';
-                return uiUtil.systemAlert('We could not get a handle to the previously picked file or folder!<br>' +
-                    'This is probably because the contents of the folder have changed. Please try picking it again.');
-            }
-            if (handle.kind === 'directory') {
-                params.pickedFolder = handle;
-                return setLocalArchiveFromArchiveList(params.storedFile);
-            } else if (handle.kind === 'file') {
-                return handle.getFile().then(function (file) {
-                    params.pickedFile = file;
-                    params.pickedFile.handle = handle;
-                    return setLocalArchiveFromArchiveList(selected);
-                }).catch(function (err) {
-                    console.error('Unable to read previously picked file!', err);
-                    uiUtil.systemAlert('We could not retrieve the previously picked file or folder!<br>Please try picking it again.');
+    var selectViaFSHandles = function () {
+        if (window.showOpenFilePicker || params.useOPFS) {
+            return getNativeFSHandle(function (handle) {
+                resetUI();
+                if (!handle) {
+                    if (window.fs && params.storedFilePath) {
+                        // Fall back to using the Electron APIs
+                        params.pickedFolder = params.storedFilePath.replace(/[^\\/]+$/, '');
+                        return setLocalArchiveFromArchiveList(selected);
+                    }
+                    console.error('No handle was retrieved');
                     document.getElementById('openLocalFiles').style.display = 'block';
                     document.getElementById('rescanStorage').style.display = 'none';
-                });
-            }
-        });
-    } else if (typeof MSApp === 'undefined' && !window.fs && params.webkitdirectory) {
-        // If we don't have any picked files or directories...
-        if (!archiveDirLegacy.files.length && !archiveFilesLegacy.files.length) {
-            appstate.waitForFileSelect = selected;
-            // No files are set, so we need to ask user to select the file or directory again
-            if (params.pickedFolder || document.getElementById('archiveList').options.length > 1) {
-                archiveDirLegacy.click();
+                    return uiUtil.systemAlert('We could not get a handle to the previously picked file or folder!<br>' +
+                        'This is probably because the contents of the folder have changed. Please try picking it again.');
+                }
+                if (handle.kind === 'directory') {
+                    params.pickedFolder = handle;
+                    return setLocalArchiveFromArchiveList(params.storedFile);
+                } else if (handle.kind === 'file') {
+                    return handle.getFile().then(function (file) {
+                        params.pickedFile = file;
+                        params.pickedFile.handle = handle;
+                        return setLocalArchiveFromArchiveList(selected);
+                    }).catch(function (err) {
+                        console.error('Unable to read previously picked file!', err);
+                        uiUtil.systemAlert('We could not retrieve the previously picked file or folder!<br>Please try picking it again.');
+                        document.getElementById('openLocalFiles').style.display = 'block';
+                        document.getElementById('rescanStorage').style.display = 'none';
+                    });
+                }
+            });
+        } else if (typeof MSApp === 'undefined' && !window.fs && params.webkitdirectory) {
+            // If we don't have any picked files or directories...
+            if (!archiveDirLegacy.files.length && !archiveFilesLegacy.files.length) {
+                appstate.waitForFileSelect = selected;
+                // No files are set, so we need to ask user to select the file or directory again
+                if (params.pickedFolder || document.getElementById('archiveList').options.length > 1) {
+                    archiveDirLegacy.click();
+                } else {
+                    archiveFilesLegacy.click();
+                }
             } else {
-                archiveFilesLegacy.click();
+                console.debug('Files are set, attempting to select ' + selected);
+                params.pickedFile = selected;
+                if (archiveDirLegacy.files.length) {
+                    params.pickedFolder = archiveDirLegacy.files[0].webkitRelativePath.replace(/\/[^/]*$/, '');
+                    params.pickedFile = '';
+                }
+                setLocalArchiveFromArchiveList(selected);
             }
         } else {
-            console.debug('Files are set, attempting to select ' + selected);
-            params.pickedFile = selected;
-            if (archiveDirLegacy.files.length) {
-                params.pickedFolder = archiveDirLegacy.files[0].webkitRelativePath.replace(/\/[^/]*$/, '');
-                params.pickedFile = '';
-            }
             setLocalArchiveFromArchiveList(selected);
         }
-    } else {
-        setLocalArchiveFromArchiveList(selected);
+        setTimeout(resetUI, 0);
+    };
+    // In Electron or NWJS, prefer to load the archive with Node fs methods whenever a real
+    // path to the selected file can be verified: loading through a File System Access handle
+    // is less reliable in these frameworks (Chromium File snapshots can be invalidated on
+    // Windows by concurrent access to the underlying file), and the stored handle can be
+    // stale (e.g. after the download folder was changed with the native folder dialogue,
+    // which returns a path rather than a handle)
+    if (window.fs && !params.useOPFS) {
+        var candidateFolder = typeof params.pickedFolder === 'string' && params.pickedFolder
+            ? params.pickedFolder : settingsStore.getItem('pickedFolder');
+        if (candidateFolder && typeof candidateFolder === 'string') {
+            var folderPath = candidateFolder.replace(/[\\/]+$/, '');
+            // A bare drive letter ('W:') is drive-relative in Node, so ensure a root slash
+            if (/^[A-Za-z]:$/.test(folderPath)) folderPath += '/';
+            window.fs.stat(folderPath.replace(/\/$/, '') + '/' + selected, function (err, stats) {
+                if (!err && stats) {
+                    console.debug('Loading ' + selected + ' with Node fs from verified folder path: ' + folderPath);
+                    params.pickedFolder = folderPath;
+                    setLocalArchiveFromArchiveList(selected);
+                    setTimeout(resetUI, 0);
+                } else {
+                    // The selected archive is not at the candidate path: fall back to handles
+                    selectViaFSHandles();
+                }
+            });
+            return;
+        }
     }
-    setTimeout(resetUI, 0);
+    selectViaFSHandles();
 }
 
 // Legacy file picker is used as a fallback when all other pickers are unavailable
@@ -4332,6 +4362,10 @@ if (window.dialog) {
     dialog.on('dir-dialog', function (fullPath) {
         console.log('Path: ' + fullPath);
         fullPath = fullPath.replace(/\\/g, '/');
+        // The natively picked folder supersedes any previously picked FSA folder, so delete
+        // the stored directory handle: it would otherwise resurrect the previous folder when
+        // the archive list is refreshed or the app is relaunched
+        cache.idxDB('delete', 'pickedFSHandle', function () {});
         scanNodeFolderforArchives(fullPath);
     });
 }

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -150,6 +150,7 @@ params['useLegacyZimitSupport'] = getSetting('useLegacyZimitSupport') === true; 
 params['sourceVerification'] = params.contentInjectionMode === 'serviceworker' ? (getSetting('sourceVerification') === null ? true : getSetting('sourceVerification')) : false; // Sets a boolean indicating weather a user trusts the source of zim files
 params['interceptBeforeUnload'] = getSetting('interceptBeforeUnload') !== null ? getSetting('interceptBeforeUnload') : true; // A setting that determines whether to warn user before leaving the app (default is true)
 params['autoUpdatePWA'] = getSetting('autoUpdatePWA') !== false; // A setting that determines whether to auto-update the PWA without asking the user (default is true)
+params['keepTorrentSeeding'] = getSetting('keepTorrentSeeding') !== false; // A setting that determines whether completed in-app BitTorrent downloads keep seeding until app quit (default is true; Electron/NWJS only)
 
 // Do not touch these values unless you know what they do! Some are global variables, some are set programmatically
 params['cacheAPI'] = 'kiwixjs-assetsCache'; // Set the global Cache API database or cache name here, and synchronize with Service Worker

--- a/www/js/lib/cache.js
+++ b/www/js/lib/cache.js
@@ -708,6 +708,13 @@ function transform (string, filter) {
  */
 function verifyPermission (fileHandle, withWrite) {
     if (params.useOPFS) return Promise.resolve(true); // No permission prompt required for OPFS
+    // Guard against an invalid stored object (e.g. a path string that was persisted where a
+    // handle was expected): without this, the synchronous TypeError below would bypass the
+    // caller's Promise error handling and abort app initialization
+    if (!fileHandle || typeof fileHandle.queryPermission !== 'function') {
+        console.warn('The stored object is not a valid file system handle:', fileHandle);
+        return Promise.resolve(false);
+    }
     var opts = withWrite ? { mode: 'readwrite' } : {};
     return fileHandle.queryPermission(opts).then(function (permission) {
         if (permission === 'granted') return true;

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1257,10 +1257,11 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
              '<li><b>Magnet link</b>: <a id="magnet" href="' + URL.replace(/\.meta4$/, '.magnet') + '"' + target + '>' +
                 URL.replace(/\.meta4$/, '.magnet') + '</a> (if torrent app doesn\'t launch, <a id="magnetAlt" href="#" target="_blank">tap here</a> and copy/paste link into your app)<br /></li></ul>\r\n';
         }
-        if (megabytes > 200 && torrentClient.isAvailable() && /\.zim\.meta4$/i.test(URL)) {
+        var torrentDownloadAvailable = megabytes > 200 && torrentClient.isAvailable() && /\.zim\.meta4$/i.test(URL);
+        if (torrentDownloadAvailable) {
             bodyDoc += '<p><b>In-app BitTorrent download, for larger archives (downloads to your selected ZIM folder):</b></p><ul>\r\n<li>' +
                 '<a href="#" id="torrentDownloadLink" data-kiwix-torrent="' + escapeHtml(URL.replace(/\.meta4$/, '.torrent')) +
-                '" style="background-color: green; color: white; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download via BitTorrent</a> (<i><b>recommended</b>: resumes automatically, even if interrupted by closing the app)</i></li></ul>\r\n';
+                '" style="background-color: green; color: yellow !important; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download via BitTorrent</a> (<i><b>recommended</b>: resumes automatically, even if interrupted by closing the app)</i></li></ul>\r\n';
         }
         if (megabytes > 4000 && /\.zim\.meta4$/i.test(URL)) {
             bodyDoc += '<p style="color:red;">If you plan to store this archive on a drive/microSD formatted as <b>FAT32</b> (most are not), then you will need to download the file on a PC and split it into chunks less than 4GB: see <a href="https://github.com/kiwix/kiwix-js-pwa/tree/main/AppPackages#download-a-zim-archive-all-platforms" target="_blank">Download a ZIM archive</a>.</p>\r\n';
@@ -1279,7 +1280,8 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
             bodyDoc += '<p><b>Direct download';
             bodyDoc += params.useOPFS ? ' to Origin Private File System' : ' to your ZIM folder';
             bodyDoc += ', for smaller archives:</b> (<i>downloads archive in-app</i>)</p><ul>\r\n<li>' +
-                '<a href="' + mirrorZimUrl + '" class="download" style="background-color: green; color: white; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download now</a> ' +
+                '<a href="' + mirrorZimUrl + '" class="download" style="background-color: ' + (torrentDownloadAvailable ? 'goldenrod; color: navy !important' : 'green; color: yellow !important') +
+                '; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Direct download</a> ' +
                 '<a href="' + mirrorZimUrl + '" class="download">' + mirrorZimUrl + '</a></li></ul>\r\n';
             bodyDoc += '<p><b>Browser-managed download from mirrors, for larger archives:</b>';
         } else {

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1816,7 +1816,7 @@ if (torrentClient.isAvailable()) {
         }
         if (!pendingResume || !pendingResume.torrentUrl || !pendingResume.savePath) return;
         setTimeout(function () {
-            uiUtil.systemAlert('<p>A BitTorrent download of <i>' + (pendingResume.name || 'an archive') +
+            uiUtil.systemAlert('<p>A BitTorrent download of <i>' + escapeHtml(pendingResume.name || 'an archive') +
                 '</i> did not finish because the app was closed.</p>' +
                 '<p>Do you want to resume it now? (<i>The data already downloaded has been kept.</i>)</p>',
             'Resume BitTorrent download?', true, 'Discard', 'Resume').then(function (resume) {
@@ -1842,7 +1842,7 @@ if (torrentClient.isAvailable()) {
  */
 function startTorrentDownload (torrentUrl, sizeMB) {
     if (activeTorrent) {
-        uiUtil.systemAlert('<p>A BitTorrent download is already in progress:</p><ul><li><i>' + activeTorrent.name + '</i></li></ul>' +
+        uiUtil.systemAlert('<p>A BitTorrent download is already in progress:</p><ul><li><i>' + escapeHtml(activeTorrent.name) + '</i></li></ul>' +
             '<p>Do you wish to stop it? (<i>Partially downloaded data will be kept, so the download can be resumed later.</i>)</p>',
         'Stop BitTorrent download?', true, 'Continue downloading', 'Stop download').then(function (result) {
             if (result && activeTorrent) {
@@ -1926,7 +1926,7 @@ function beginTorrentDownload (torrentUrl, savePath) {
             } else if (s.seeding && serverResponse.style.display !== 'none') {
                 // The download has completed, but we are still seeding the archive
                 serverResponse.style.setProperty('color', 'green', 'important');
-                serverResponse.innerHTML = 'Seeding ' + s.name + ': uploaded ' + (s.uploaded / 1048576).toFixed(1) +
+                serverResponse.innerHTML = 'Seeding ' + escapeHtml(s.name) + ': uploaded ' + (s.uploaded / 1048576).toFixed(1) +
                     ' MB (' + s.numPeers + ' peer' + (s.numPeers === 1 ? '' : 's') + ')';
             }
         },
@@ -1940,7 +1940,7 @@ function beginTorrentDownload (torrentUrl, savePath) {
                 torrentClient.detach(s.infoHash);
             }
             reportDownloadProgress('completed');
-            uiUtil.systemAlert('<p>The archive <i>' + s.name + '</i> has been downloaded to your device' +
+            uiUtil.systemAlert('<p>The archive <i>' + escapeHtml(s.name) + '</i> has been downloaded to your device' +
                 (s.verified ? ' and its data has been verified' : '') + '.</p>' +
                 (s.seeding ? '<p><i>The app will go on sharing (seeding) this archive with other users until you close the app.</i></p>' : ''),
             'Download complete').then(function () {
@@ -1955,7 +1955,7 @@ function beginTorrentDownload (torrentUrl, savePath) {
             percentageComplete = 0;
             clearActiveTorrent();
             uiUtil.pollOpsPanel();
-            uiUtil.systemAlert('<p>The BitTorrent download failed:</p><p>' + message +
+            uiUtil.systemAlert('<p>The BitTorrent download failed:</p><p>' + escapeHtml(message) +
                 '</p><p>Any partially downloaded data will be reused if you try again.</p>', 'Download failed');
         }
     }).then(function (status) {
@@ -1971,7 +1971,7 @@ function beginTorrentDownload (torrentUrl, savePath) {
         percentageComplete = 0;
         clearActiveTorrent();
         uiUtil.pollOpsPanel();
-        uiUtil.systemAlert('<p>Unable to start the BitTorrent download:</p><p>' + (err.message || err) + '</p>', 'Download failed');
+        uiUtil.systemAlert('<p>Unable to start the BitTorrent download:</p><p>' + escapeHtml(err.message || err) + '</p>', 'Download failed');
     });
 }
 
@@ -2032,8 +2032,10 @@ function showSeedingStatus () {
         if (!s || !s.seeding || !seedingTorrent) return;
         serverResponse.style.display = 'inline';
         serverResponse.style.setProperty('color', 'green', 'important');
-        serverResponse.innerHTML = 'Seeding ' + s.name + ': uploaded ' + (s.uploaded / 1048576).toFixed(1) +
+        serverResponse.innerHTML = 'Seeding ' + escapeHtml(s.name) + ': uploaded ' + (s.uploaded / 1048576).toFixed(1) +
             ' MB (' + s.numPeers + ' peer' + (s.numPeers === 1 ? '' : 's') + ')';
+    }).catch(function (err) {
+        console.warn('[kiwixServe] Could not refresh seeding status', err);
     });
 }
 

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -2019,8 +2019,27 @@ function reportDownloadProgress (received, total) {
     }
 }
 
+/**
+ * Clears the "Seeding ..." status line when the user turns off "Keep seeding". The backend
+ * stops the completed torrent, but that also ends the onProgress events that drive the line,
+ * so the renderer must detach the torrent and clear the now-frozen message itself. Has no
+ * effect if nothing is currently seeding.
+ */
+function clearSeedingStatus () {
+    if (!seedingTorrent) return;
+    torrentClient.detach(seedingTorrent.infoHash);
+    seedingTorrent = null;
+    serverResponse.style.removeProperty('color');
+    if (document.getElementById('downloadLinks').style.display === 'none') {
+        serverResponse.style.display = 'none';
+    } else {
+        serverResponse.innerHTML = '';
+    }
+}
+
 export default {
     // langCodes: langCodes,
     requestXhttpData: requestXhttpData,
-    reportDownloadProgress: reportDownloadProgress
+    reportDownloadProgress: reportDownloadProgress,
+    clearSeedingStatus: clearSeedingStatus
 };

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1756,6 +1756,35 @@ var seedingTorrent = null;
 // A torrent start request that is waiting for the user to pick a download folder
 var pendingTorrentUrl = null;
 
+// settingsStore key remembering a BitTorrent download that is (or was) in progress, so that if
+// the app is closed or crashes before it finishes, the user can be offered to resume it on the
+// next launch. The partial data itself is always kept on disk regardless of this record; it
+// only remembers where to find it again. Cleared as soon as the download finishes, fails, or is
+// stopped by the user.
+var ACTIVE_TORRENT_KEY = 'activeTorrentDownload';
+
+/**
+ * Remembers an in-progress BitTorrent download across app restarts
+ * @param {String} torrentUrl The URL of the .torrent file being downloaded
+ * @param {String} savePath The absolute path of the folder it is being saved into
+ * @param {String} [name] The archive's name, once known, for a friendlier resume prompt
+ */
+function persistActiveTorrent (torrentUrl, savePath, name) {
+    settingsStore.setItem(ACTIVE_TORRENT_KEY, JSON.stringify({
+        torrentUrl: torrentUrl,
+        savePath: savePath,
+        name: name || null
+    }), Infinity);
+}
+
+/**
+ * Forgets any remembered in-progress BitTorrent download (called once it finishes, fails, or
+ * is explicitly stopped, so that it is no longer offered for resumption on a future launch)
+ */
+function clearActiveTorrent () {
+    settingsStore.removeItem(ACTIVE_TORRENT_KEY);
+}
+
 // If the user had to pick a folder before a torrent could start, the chosen path arrives
 // here (as well as in app.js, which scans the folder and sets params.pickedFolder)
 if (window.dialog && torrentClient.isAvailable()) {
@@ -1765,6 +1794,40 @@ if (window.dialog && torrentClient.isAvailable()) {
             pendingTorrentUrl = null;
             beginTorrentDownload(torrentUrl, fullPath.replace(/\\/g, '/'));
         }
+    });
+}
+
+// If a BitTorrent download was still in progress when the app last quit (or crashed), offer to
+// resume it now. Deferred to DOMContentLoaded, and further delayed with setTimeout, because the
+// modal dialogue depends on bootstrap/jQuery having been injected, which is not guaranteed yet
+// at this point on all platforms (see the similar splash-screen modal delay in app.js)
+if (torrentClient.isAvailable()) {
+    document.addEventListener('DOMContentLoaded', function () {
+        var pendingResumeJSON = settingsStore.getItem(ACTIVE_TORRENT_KEY);
+        var pendingResume = null;
+        if (pendingResumeJSON) {
+            try {
+                pendingResume = JSON.parse(pendingResumeJSON);
+            } catch (e) {
+                pendingResume = null;
+            }
+        }
+        if (!pendingResume || !pendingResume.torrentUrl || !pendingResume.savePath) return;
+        setTimeout(function () {
+            uiUtil.systemAlert('<p>A BitTorrent download of <i>' + (pendingResume.name || 'an archive') +
+                '</i> did not finish because the app was closed.</p>' +
+                '<p>Do you want to resume it now? (<i>The data already downloaded has been kept.</i>)</p>',
+            'Resume BitTorrent download?', true, 'Discard', 'Resume').then(function (resume) {
+                if (resume) {
+                    beginTorrentDownload(pendingResume.torrentUrl, pendingResume.savePath);
+                } else {
+                    clearActiveTorrent();
+                    torrentClient.deletePartial(pendingResume.savePath, pendingResume.name).catch(function (err) {
+                        console.warn('[kiwixServe] Could not delete discarded partial download', err);
+                    });
+                }
+            });
+        }, 1500);
     });
 }
 
@@ -1785,6 +1848,7 @@ function startTorrentDownload (torrentUrl, sizeMB) {
                 activeTorrent = null;
                 downloadSize = 0;
                 percentageComplete = 0;
+                clearActiveTorrent();
                 uiUtil.pollOpsPanel();
                 serverResponse.style.display = 'none';
             }
@@ -1843,6 +1907,9 @@ function beginTorrentDownload (torrentUrl, savePath) {
     // Guards against a race where a torrent completes (or fails) before the start Promise
     // resolves, e.g. when resuming a file that is already fully downloaded
     var finished = false;
+    // Remembered now (before the name is known) so that even a crash during the initial fetch
+    // or hash-check of on-disk data is still offered for resumption on the next launch
+    persistActiveTorrent(torrentUrl, savePath);
     uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Starting BitTorrent download...', true);
     torrentClient.start(torrentUrl, savePath, {
         onProgress: function (s) {
@@ -1865,6 +1932,7 @@ function beginTorrentDownload (torrentUrl, savePath) {
         onDone: function (s) {
             finished = true;
             activeTorrent = null;
+            clearActiveTorrent();
             if (s.seeding) {
                 seedingTorrent = { infoHash: s.infoHash, name: s.name };
             } else {
@@ -1884,16 +1952,23 @@ function beginTorrentDownload (torrentUrl, savePath) {
             activeTorrent = null;
             downloadSize = 0;
             percentageComplete = 0;
+            clearActiveTorrent();
             uiUtil.pollOpsPanel();
             uiUtil.systemAlert('<p>The BitTorrent download failed:</p><p>' + message +
                 '</p><p>Any partially downloaded data will be reused if you try again.</p>', 'Download failed');
         }
     }).then(function (status) {
-        if (!finished) activeTorrent = { infoHash: status.infoHash, name: status.name };
+        if (!finished) {
+            activeTorrent = { infoHash: status.infoHash, name: status.name };
+            // Update the remembered record with the archive's real name for a friendlier
+            // resume prompt (a plain retry of the same call is cheap: settingsStore is local)
+            persistActiveTorrent(torrentUrl, savePath, status.name);
+        }
     }).catch(function (err) {
         activeTorrent = null;
         downloadSize = 0;
         percentageComplete = 0;
+        clearActiveTorrent();
         uiUtil.pollOpsPanel();
         uiUtil.systemAlert('<p>Unable to start the BitTorrent download:</p><p>' + (err.message || err) + '</p>', 'Download failed');
     });

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1751,6 +1751,8 @@ var downloadSize = 0;
 
 // State of any in-app BitTorrent download in progress ({ infoHash, name } or null)
 var activeTorrent = null;
+// A completed torrent that is still seeding in the background ({ infoHash, name } or null)
+var seedingTorrent = null;
 // A torrent start request that is waiting for the user to pick a download folder
 var pendingTorrentUrl = null;
 
@@ -1796,7 +1798,8 @@ function startTorrentDownload (torrentUrl, sizeMB) {
     torrentClient.resolveSavePath(params.pickedFolder).then(function (savePath) {
         var message = '<p>Do you wish to download this archive with the app\'s built-in BitTorrent client?</p>' +
             (sizeMB ? '<ul><li><b>' + sizeMB + ' MB</b></li></ul>' : '') +
-            (savePath ? '<p>The archive will be downloaded to <b>' + escapeHtml(savePath) + '</b>.</p>'
+            (savePath ? '<p>The archive will be downloaded to <b>' + escapeHtml(savePath) + '</b>.</p>' +
+                '<p><label><input type="checkbox" id="torrentPickNewFolder">&nbsp;Download to a different folder&hellip;</label></p>'
                 : '<p>You will be asked to choose the folder into which the archive should be downloaded (usually your ZIM folder).</p>') +
             '<p>The download can be resumed if it is interrupted. Your firewall may ask you (once) to allow the app to accept network connections: ' +
             'this is needed to exchange data with other BitTorrent users.</p>' +
@@ -1805,10 +1808,15 @@ function startTorrentDownload (torrentUrl, sizeMB) {
             '<p><b><i>Do not close the app during the download.</i></b></p>';
         uiUtil.systemAlert(message, 'Download via BitTorrent?', true, 'Cancel', 'Download').then(function (confirm) {
             if (!confirm) return;
-            if (savePath) {
+            // The modal's content is still in the DOM after it closes, so the checkbox
+            // (present only when a download path was derived) can be read here
+            var pickNewFolder = document.getElementById('torrentPickNewFolder');
+            if (savePath && !(pickNewFolder && pickNewFolder.checked)) {
                 beginTorrentDownload(torrentUrl, savePath);
             } else if (window.dialog) {
-                // Last resort: open the native (path-returning) folder picker directly
+                // No path could be derived, or the user asked to change folder: open the
+                // native (path-returning) folder picker, whose result is also stored as the
+                // new picked folder for subsequent downloads
                 pendingTorrentUrl = torrentUrl;
                 window.dialog.openDirectory();
             } else {
@@ -1826,13 +1834,24 @@ function startTorrentDownload (torrentUrl, sizeMB) {
 function beginTorrentDownload (torrentUrl, savePath) {
     downloadSize = 0;
     percentageComplete = 0;
+    // A torrent left seeding in the background must stop reporting to the status line now
+    // that a new download is taking it over (the old torrent goes on seeding regardless)
+    if (seedingTorrent) {
+        torrentClient.detach(seedingTorrent.infoHash);
+        seedingTorrent = null;
+    }
     // Guards against a race where a torrent completes (or fails) before the start Promise
     // resolves, e.g. when resuming a file that is already fully downloaded
     var finished = false;
     uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Starting BitTorrent download...', true);
     torrentClient.start(torrentUrl, savePath, {
         onProgress: function (s) {
-            if (!s.done) {
+            if (s.verifying) {
+                // The download has completed and the data written to disk is being hash-checked
+                serverResponse.style.display = 'inline';
+                serverResponse.style.setProperty('color', 'goldenrod', 'important');
+                serverResponse.innerHTML = 'Verifying downloaded data&hellip; ' + Math.round(s.progress * 100) + '%';
+            } else if (!s.done) {
                 reportDownloadProgress(s.received, s.total);
                 serverResponse.innerHTML += ' | ' + s.numPeers + ' peer' + (s.numPeers === 1 ? '' : 's') +
                     ' | ' + (s.downloadSpeed / 1048576).toFixed(2) + ' MB/s';
@@ -1846,8 +1865,14 @@ function beginTorrentDownload (torrentUrl, savePath) {
         onDone: function (s) {
             finished = true;
             activeTorrent = null;
+            if (s.seeding) {
+                seedingTorrent = { infoHash: s.infoHash, name: s.name };
+            } else {
+                torrentClient.detach(s.infoHash);
+            }
             reportDownloadProgress('completed');
-            uiUtil.systemAlert('<p>The archive <i>' + s.name + '</i> has been downloaded to your device.</p>' +
+            uiUtil.systemAlert('<p>The archive <i>' + s.name + '</i> has been downloaded to your device' +
+                (s.verified ? ' and its data has been verified' : '') + '.</p>' +
                 (s.seeding ? '<p><i>The app will go on sharing (seeding) this archive with other users until you close the app.</i></p>' : ''),
             'Download complete').then(function () {
                 var btnRefresh = document.getElementById('btnRefresh');

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -37,6 +37,7 @@
 import cache from './cache.js';
 import uiUtil from './uiUtil.js';
 import settingsStore from './settingsStore.js';
+import torrentClient from './torrentClient.js';
 
 /* globals params, appstate */
 
@@ -1256,6 +1257,11 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
              '<li><b>Magnet link</b>: <a id="magnet" href="' + URL.replace(/\.meta4$/, '.magnet') + '"' + target + '>' +
                 URL.replace(/\.meta4$/, '.magnet') + '</a> (if torrent app doesn\'t launch, <a id="magnetAlt" href="#" target="_blank">tap here</a> and copy/paste link into your app)<br /></li></ul>\r\n';
         }
+        if (megabytes > 200 && torrentClient.isAvailable() && /\.zim\.meta4$/i.test(URL)) {
+            bodyDoc += '<p><b>In-app BitTorrent download, for larger archives:</b> (<i>downloads to your ZIM folder, and can be resumed if interrupted</i>)</p><ul>\r\n<li>' +
+                '<a href="#" id="torrentDownloadLink" data-kiwix-torrent="' + escapeHtml(URL.replace(/\.meta4$/, '.torrent')) +
+                '" style="background-color: green; color: white; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download via BitTorrent</a></li></ul>\r\n';
+        }
         if (megabytes > 4000 && /\.zim\.meta4$/i.test(URL)) {
             bodyDoc += '<p style="color:red;">If you plan to store this archive on a drive/microSD formatted as <b>FAT32</b> (most are not), then you will need to download the file on a PC and split it into chunks less than 4GB: see <a href="https://github.com/kiwix/kiwix-js-pwa/tree/main/AppPackages#download-a-zim-archive-all-platforms" target="_blank">Download a ZIM archive</a>.</p>\r\n';
             // bodyDoc += '<p><b>To browse for a split version of this archive click here: <a id="portable" href="#" data-kiwix-dl="' +
@@ -1301,6 +1307,14 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
         // Add event listener for click on return link, to go back to list of archives
         var returnLink = document.getElementById('returnLink');
         if (returnLink) returnLink.addEventListener('click', submitSelectValues);
+        // Add event listener for the in-app BitTorrent download link (Electron / NWJS only)
+        var torrentLink = document.getElementById('torrentDownloadLink');
+        if (torrentLink) {
+            torrentLink.addEventListener('click', function (e) {
+                e.preventDefault();
+                startTorrentDownload(torrentLink.dataset.kiwixTorrent, megabytes$);
+            });
+        }
         // Set up preview link
         document.getElementById('preview').href = URL.replace(/^[^/]+\/\/[^/]+\/.+\/([^/]+)\.zim.+$/i, params.kiwixLibraryBrowser + '/content/$1');
         // If File System Access API is available, add event listeners on download links to save to local storage
@@ -1734,6 +1748,124 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
 
 var percentageComplete = 0;
 var downloadSize = 0;
+
+// State of any in-app BitTorrent download in progress ({ infoHash, name } or null)
+var activeTorrent = null;
+// A torrent start request that is waiting for the user to pick a download folder
+var pendingTorrentUrl = null;
+
+// If the user had to pick a folder before a torrent could start, the chosen path arrives
+// here (as well as in app.js, which scans the folder and sets params.pickedFolder)
+if (window.dialog && torrentClient.isAvailable()) {
+    window.dialog.on('dir-dialog', function (fullPath) {
+        if (pendingTorrentUrl && fullPath) {
+            var torrentUrl = pendingTorrentUrl;
+            pendingTorrentUrl = null;
+            beginTorrentDownload(torrentUrl, fullPath.replace(/\\/g, '/'));
+        }
+    });
+}
+
+/**
+ * Entry point for the in-app BitTorrent download link: confirms with the user, obtains a
+ * real filesystem path to download to, and starts the download; if a download is already
+ * in progress, offers to stop it instead
+ * @param {String} torrentUrl The URL of the .torrent file for the archive
+ * @param {String} sizeMB The formatted size of the archive in MB (for display only)
+ */
+function startTorrentDownload (torrentUrl, sizeMB) {
+    if (activeTorrent) {
+        uiUtil.systemAlert('<p>A BitTorrent download is already in progress:</p><ul><li><i>' + activeTorrent.name + '</i></li></ul>' +
+            '<p>Do you wish to stop it? (<i>Partially downloaded data will be kept, so the download can be resumed later.</i>)</p>',
+        'Stop BitTorrent download?', true, 'Continue downloading', 'Stop download').then(function (result) {
+            if (result && activeTorrent) {
+                torrentClient.stop(activeTorrent.infoHash, false);
+                activeTorrent = null;
+                downloadSize = 0;
+                percentageComplete = 0;
+                uiUtil.pollOpsPanel();
+                serverResponse.style.display = 'none';
+            }
+        });
+        return;
+    }
+    var message = '<p>Do you wish to download this archive with the app\'s built-in BitTorrent client?</p>' +
+        (sizeMB ? '<ul><li><b>' + sizeMB + ' MB</b></li></ul>' : '') +
+        '<p>The download can be resumed if it is interrupted. Your firewall may ask you (once) to allow the app to accept network connections: ' +
+        'this is needed to exchange data with other BitTorrent users.</p>' +
+        (params.keepTorrentSeeding ? '<p><i>After the download completes, the app will continue to share (seed) the archive with other users until you close the app. ' +
+            'You can turn this off under Download library in Configuration.</i></p>' : '') +
+        '<p><b><i>Do not close the app during the download.</i></b></p>';
+    uiUtil.systemAlert(message, 'Download via BitTorrent?', true, 'Cancel', 'Download').then(function (confirm) {
+        if (!confirm) return;
+        if (typeof params.pickedFolder === 'string' && params.pickedFolder) {
+            beginTorrentDownload(torrentUrl, params.pickedFolder);
+        } else {
+            // The torrent client runs in the Node context and needs a real filesystem path
+            uiUtil.systemAlert('<p>Please choose the folder to which the archive should be downloaded (usually your ZIM archive folder).</p>',
+                'Choose download folder').then(function () {
+                pendingTorrentUrl = torrentUrl;
+                window.dialog.openDirectory();
+            });
+        }
+    });
+}
+
+/**
+ * Starts the torrent download and wires its progress, completion and error events to the UI
+ * @param {String} torrentUrl The URL of the .torrent file for the archive
+ * @param {String} savePath The absolute path of the folder to download into
+ */
+function beginTorrentDownload (torrentUrl, savePath) {
+    downloadSize = 0;
+    percentageComplete = 0;
+    // Guards against a race where a torrent completes (or fails) before the start Promise
+    // resolves, e.g. when resuming a file that is already fully downloaded
+    var finished = false;
+    uiUtil.pollOpsPanel('<span class="glyphicon glyphicon-refresh spinning"></span>&emsp;<b>Please wait:</b> Starting BitTorrent download...', true);
+    torrentClient.start(torrentUrl, savePath, {
+        onProgress: function (s) {
+            if (!s.done) {
+                reportDownloadProgress(s.received, s.total);
+                serverResponse.innerHTML += ' | ' + s.numPeers + ' peer' + (s.numPeers === 1 ? '' : 's') +
+                    ' | ' + (s.downloadSpeed / 1048576).toFixed(2) + ' MB/s';
+            } else if (s.seeding && serverResponse.style.display !== 'none') {
+                // The download has completed, but we are still seeding the archive
+                serverResponse.style.setProperty('color', 'green', 'important');
+                serverResponse.innerHTML = 'Seeding ' + s.name + ': uploaded ' + (s.uploaded / 1048576).toFixed(1) +
+                    ' MB (' + s.numPeers + ' peer' + (s.numPeers === 1 ? '' : 's') + ')';
+            }
+        },
+        onDone: function (s) {
+            finished = true;
+            activeTorrent = null;
+            reportDownloadProgress('completed');
+            uiUtil.systemAlert('<p>The archive <i>' + s.name + '</i> has been downloaded to your device.</p>' +
+                (s.seeding ? '<p><i>The app will go on sharing (seeding) this archive with other users until you close the app.</i></p>' : ''),
+            'Download complete').then(function () {
+                var btnRefresh = document.getElementById('btnRefresh');
+                if (btnRefresh) btnRefresh.click();
+            });
+        },
+        onError: function (message) {
+            finished = true;
+            activeTorrent = null;
+            downloadSize = 0;
+            percentageComplete = 0;
+            uiUtil.pollOpsPanel();
+            uiUtil.systemAlert('<p>The BitTorrent download failed:</p><p>' + message +
+                '</p><p>Any partially downloaded data will be reused if you try again.</p>', 'Download failed');
+        }
+    }).then(function (status) {
+        if (!finished) activeTorrent = { infoHash: status.infoHash, name: status.name };
+    }).catch(function (err) {
+        activeTorrent = null;
+        downloadSize = 0;
+        percentageComplete = 0;
+        uiUtil.pollOpsPanel();
+        uiUtil.systemAlert('<p>Unable to start the BitTorrent download:</p><p>' + (err.message || err) + '</p>', 'Download failed');
+    });
+}
 
 /**
  * Reports download progress to the serverResponse panel

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1789,25 +1789,32 @@ function startTorrentDownload (torrentUrl, sizeMB) {
         });
         return;
     }
-    var message = '<p>Do you wish to download this archive with the app\'s built-in BitTorrent client?</p>' +
-        (sizeMB ? '<ul><li><b>' + sizeMB + ' MB</b></li></ul>' : '') +
-        '<p>The download can be resumed if it is interrupted. Your firewall may ask you (once) to allow the app to accept network connections: ' +
-        'this is needed to exchange data with other BitTorrent users.</p>' +
-        (params.keepTorrentSeeding ? '<p><i>After the download completes, the app will continue to share (seed) the archive with other users until you close the app. ' +
-            'You can turn this off under Download library in Configuration.</i></p>' : '') +
-        '<p><b><i>Do not close the app during the download.</i></b></p>';
-    uiUtil.systemAlert(message, 'Download via BitTorrent?', true, 'Cancel', 'Download').then(function (confirm) {
-        if (!confirm) return;
-        if (typeof params.pickedFolder === 'string' && params.pickedFolder) {
-            beginTorrentDownload(torrentUrl, params.pickedFolder);
-        } else {
-            // The torrent client runs in the Node context and needs a real filesystem path
-            uiUtil.systemAlert('<p>Please choose the folder to which the archive should be downloaded (usually your ZIM archive folder).</p>',
-                'Choose download folder').then(function () {
+    // The torrent backend runs in the Node context and needs a real filesystem path, which is
+    // derived from the picked folder (including FSA directory handles) where possible; we
+    // resolve it before showing the dialogue so the destination (or the need to pick one) can
+    // be stated up front
+    torrentClient.resolveSavePath(params.pickedFolder).then(function (savePath) {
+        var message = '<p>Do you wish to download this archive with the app\'s built-in BitTorrent client?</p>' +
+            (sizeMB ? '<ul><li><b>' + sizeMB + ' MB</b></li></ul>' : '') +
+            (savePath ? '<p>The archive will be downloaded to <b>' + escapeHtml(savePath) + '</b>.</p>'
+                : '<p>You will be asked to choose the folder into which the archive should be downloaded (usually your ZIM folder).</p>') +
+            '<p>The download can be resumed if it is interrupted. Your firewall may ask you (once) to allow the app to accept network connections: ' +
+            'this is needed to exchange data with other BitTorrent users.</p>' +
+            (params.keepTorrentSeeding ? '<p><i>After the download completes, the app will continue to share (seed) the archive with other users until you close the app. ' +
+                'You can turn this off under Download library in Configuration.</i></p>' : '') +
+            '<p><b><i>Do not close the app during the download.</i></b></p>';
+        uiUtil.systemAlert(message, 'Download via BitTorrent?', true, 'Cancel', 'Download').then(function (confirm) {
+            if (!confirm) return;
+            if (savePath) {
+                beginTorrentDownload(torrentUrl, savePath);
+            } else if (window.dialog) {
+                // Last resort: open the native (path-returning) folder picker directly
                 pendingTorrentUrl = torrentUrl;
                 window.dialog.openDirectory();
-            });
-        }
+            } else {
+                uiUtil.systemAlert('<p>Unable to establish a folder to download the archive into. Please pick your ZIM folder in Configuration first.</p>', 'No download folder');
+            }
+        });
     });
 }
 

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -2020,6 +2020,24 @@ function reportDownloadProgress (received, total) {
 }
 
 /**
+ * (Re)populates the "Seeding ..." status line from the torrent's current status and makes it
+ * visible, so the user can monitor an ongoing background seed whenever they open the Library
+ * panel (which otherwise hides the line). Subsequent live onProgress events then keep it current
+ * while the panel is open. A no-op if nothing is currently seeding.
+ */
+function showSeedingStatus () {
+    if (!seedingTorrent) return;
+    torrentClient.getStatus(seedingTorrent.infoHash).then(function (s) {
+        // The torrent may have been stopped in the meantime (e.g. seeding turned off)
+        if (!s || !s.seeding || !seedingTorrent) return;
+        serverResponse.style.display = 'inline';
+        serverResponse.style.setProperty('color', 'green', 'important');
+        serverResponse.innerHTML = 'Seeding ' + s.name + ': uploaded ' + (s.uploaded / 1048576).toFixed(1) +
+            ' MB (' + s.numPeers + ' peer' + (s.numPeers === 1 ? '' : 's') + ')';
+    });
+}
+
+/**
  * Clears the "Seeding ..." status line when the user turns off "Keep seeding". The backend
  * stops the completed torrent, but that also ends the onProgress events that drive the line,
  * so the renderer must detach the torrent and clear the now-frozen message itself. Has no
@@ -2041,5 +2059,6 @@ export default {
     // langCodes: langCodes,
     requestXhttpData: requestXhttpData,
     reportDownloadProgress: reportDownloadProgress,
-    clearSeedingStatus: clearSeedingStatus
+    clearSeedingStatus: clearSeedingStatus,
+    showSeedingStatus: showSeedingStatus
 };

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1258,9 +1258,9 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
                 URL.replace(/\.meta4$/, '.magnet') + '</a> (if torrent app doesn\'t launch, <a id="magnetAlt" href="#" target="_blank">tap here</a> and copy/paste link into your app)<br /></li></ul>\r\n';
         }
         if (megabytes > 200 && torrentClient.isAvailable() && /\.zim\.meta4$/i.test(URL)) {
-            bodyDoc += '<p><b>In-app BitTorrent download, for larger archives:</b> (<i>downloads to your ZIM folder, and can be resumed if interrupted</i>)</p><ul>\r\n<li>' +
+            bodyDoc += '<p><b>In-app BitTorrent download, for larger archives (downloads to your selected ZIM folder):</b></p><ul>\r\n<li>' +
                 '<a href="#" id="torrentDownloadLink" data-kiwix-torrent="' + escapeHtml(URL.replace(/\.meta4$/, '.torrent')) +
-                '" style="background-color: green; color: white; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download via BitTorrent</a></li></ul>\r\n';
+                '" style="background-color: green; color: white; padding: 2px 5px; border-radius: 3px; text-decoration: none;">Download via BitTorrent</a> (<i><b>recommended</b>: resumes automatically, even if interrupted by closing the app)</i></li></ul>\r\n';
         }
         if (megabytes > 4000 && /\.zim\.meta4$/i.test(URL)) {
             bodyDoc += '<p style="color:red;">If you plan to store this archive on a drive/microSD formatted as <b>FAT32</b> (most are not), then you will need to download the file on a PC and split it into chunks less than 4GB: see <a href="https://github.com/kiwix/kiwix-js-pwa/tree/main/AppPackages#download-a-zim-archive-all-platforms" target="_blank">Download a ZIM archive</a>.</p>\r\n';
@@ -1865,11 +1865,10 @@ function startTorrentDownload (torrentUrl, sizeMB) {
             (savePath ? '<p>The archive will be downloaded to <b>' + escapeHtml(savePath) + '</b>.</p>' +
                 '<p><label><input type="checkbox" id="torrentPickNewFolder">&nbsp;Download to a different folder&hellip;</label></p>'
                 : '<p>You will be asked to choose the folder into which the archive should be downloaded (usually your ZIM folder).</p>') +
-            '<p>The download can be resumed if it is interrupted. Your firewall may ask you (once) to allow the app to accept network connections: ' +
-            'this is needed to exchange data with other BitTorrent users.</p>' +
+            '<p>The download can be resumed if it is interrupted — even by closing the app: you will be offered to continue it the next time you open the app. ' +
+            'Your firewall may ask you (once) to allow the app to accept network connections: this is needed to exchange data with other BitTorrent users.</p>' +
             (params.keepTorrentSeeding ? '<p><i>After the download completes, the app will continue to share (seed) the archive with other users until you close the app. ' +
-                'You can turn this off under Download library in Configuration.</i></p>' : '') +
-            '<p><b><i>Do not close the app during the download.</i></b></p>';
+                'You can turn this off under Download library in Configuration.</i></p>' : '');
         uiUtil.systemAlert(message, 'Download via BitTorrent?', true, 'Cancel', 'Download').then(function (confirm) {
             if (!confirm) return;
             // The modal's content is still in the DOM after it closes, so the checkbox

--- a/www/js/lib/torrentClient.js
+++ b/www/js/lib/torrentClient.js
@@ -19,6 +19,8 @@
 
 'use strict';
 
+import settingsStore from './settingsStore.js';
+
 // The callbacks of the currently active download ({ onProgress, onDone, onError } or null).
 // The UI only starts one torrent at a time, so a single set of callbacks is sufficient.
 var activeCallbacks = null;
@@ -102,10 +104,68 @@ function setSeeding (value) {
     if (backend === 'electron') window.electronAPI.setTorrentSeeding(value);
 }
 
+/**
+ * Derives the real filesystem path of the folder to download into, so that the torrent
+ * backend (which runs in the Node context) can write to the user's chosen folder without
+ * the app having to leave the File System Access API pathway:
+ * - if pickedFolder is already a path string (native Electron folder picking), it is used;
+ * - if it is an FSA directory handle, no path can be read from it directly (Chromium/Electron
+ *   deliberately do not expose real paths for FSA handles or the File objects they produce),
+ *   but the app stores a folder path string whenever a folder is picked with the native
+ *   dialogue, so if a file from the handle exists at that stored path, the stored path and
+ *   the handle demonstrably refer to the same folder and the path can be used.
+ * If neither works, null is returned and the caller should open the native folder picker
+ * (whose result is stored, making this a once-only event per configuration reset).
+ * @param {String|FileSystemDirectoryHandle} pickedFolder The current picked folder
+ * @returns {Promise<String|null>} A Promise for the folder path, or null if it could not
+ *   be derived
+ */
+function resolveSavePath (pickedFolder) {
+    if (typeof pickedFolder === 'string' && pickedFolder) {
+        return Promise.resolve(pickedFolder);
+    }
+    if (!pickedFolder || pickedFolder.kind !== 'directory' || !(window.fs && window.fs.stat)) {
+        return Promise.resolve(null);
+    }
+    var stored = settingsStore.getItem('pickedFolder');
+    if (!stored) return Promise.resolve(null);
+    var candidate = stored.replace(/[\\/]+$/, '');
+    // A bare drive letter ('W:') is drive-relative in Node, so ensure a root slash; other
+    // paths are used without a trailing slash
+    if (/^[A-Za-z]:$/.test(candidate)) candidate += '/';
+    // Find the name of any file inside the handle (skipping subdirectories) with which to
+    // verify the stored path
+    var iterator = pickedFolder.values();
+    var findFileName = function () {
+        return iterator.next().then(function (result) {
+            if (result.done) return null;
+            return result.value.kind === 'file' ? result.value.name : findFileName();
+        });
+    };
+    return findFileName().then(function (fileName) {
+        // An empty folder cannot be verified against the stored path
+        if (!fileName) return null;
+        return new Promise(function (resolve) {
+            window.fs.stat(candidate.replace(/\/$/, '') + '/' + fileName, function (err, stats) {
+                if (!err && stats) {
+                    console.debug('[torrentClient] Using stored folder path verified against the directory handle: ' + candidate);
+                    resolve(candidate);
+                } else {
+                    resolve(null);
+                }
+            });
+        });
+    }).catch(function (err) {
+        console.warn('[torrentClient] Could not derive a filesystem path from the directory handle', err);
+        return null;
+    });
+}
+
 export default {
     isAvailable: isAvailable,
     start: start,
     stop: stop,
     getStatus: getStatus,
-    setSeeding: setSeeding
+    setSeeding: setSeeding,
+    resolveSavePath: resolveSavePath
 };

--- a/www/js/lib/torrentClient.js
+++ b/www/js/lib/torrentClient.js
@@ -33,9 +33,11 @@ var downloadCallbacks = {};
 var startInFlight = false;
 var bufferedEvents = [];
 
-// Backend detection: 'electron' via the preload API; NWJS will be added here later
+// Backend detection: 'electron' via the preload API, but only where the runtime can actually
+// run WebTorrent (Node 20+ and a non-ia32 arch, decided in preload.cjs as torrentSupported, so
+// old/32-bit Electron builds never offer the feature); NWJS will be added here later
 // (e.g. window.nw && parseInt(nw.process.versions.node) >= 20)
-var backend = window.electronAPI && window.electronAPI.startTorrentDownload ? 'electron' : null;
+var backend = window.electronAPI && window.electronAPI.startTorrentDownload && window.electronAPI.torrentSupported ? 'electron' : null;
 
 /**
  * Routes a torrent event to the callbacks of the torrent it belongs to

--- a/www/js/lib/torrentClient.js
+++ b/www/js/lib/torrentClient.js
@@ -1,0 +1,111 @@
+/**
+ * torrentClient.js: Renderer-side adapter for in-app BitTorrent downloads of ZIM archives.
+ * Presents a single framework-neutral API to the UI, and internally selects the backend:
+ * - Electron: calls the main process (torrentDownloader.cjs) over IPC via window.electronAPI
+ * - NWJS (planned): will require torrentDownloader.cjs directly in the Node context, gated on
+ *   a modern Node runtime (so that legacy NWJS builds for XP/Vista never see the feature)
+ * - All other app types (PWA, UWP): feature is unavailable, and isAvailable() returns false
+ *
+ * Copyright 2026 Jaifroid and contributors
+ * License GPL v3:
+ *
+ * This file is part of Kiwix.
+ *
+ * Kiwix is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+'use strict';
+
+// The callbacks of the currently active download ({ onProgress, onDone, onError } or null).
+// The UI only starts one torrent at a time, so a single set of callbacks is sufficient.
+var activeCallbacks = null;
+
+// Backend detection: 'electron' via the preload API; NWJS will be added here later
+// (e.g. window.nw && parseInt(nw.process.versions.node) >= 20)
+var backend = window.electronAPI && window.electronAPI.startTorrentDownload ? 'electron' : null;
+
+if (backend === 'electron') {
+    // Register the IPC event listeners once; they dispatch to whichever download is active
+    window.electronAPI.on('torrent-progress', function (status) {
+        if (activeCallbacks && activeCallbacks.onProgress) activeCallbacks.onProgress(status);
+    });
+    window.electronAPI.on('torrent-done', function (status) {
+        if (activeCallbacks && activeCallbacks.onDone) activeCallbacks.onDone(status);
+    });
+    window.electronAPI.on('torrent-error', function (message) {
+        if (activeCallbacks && activeCallbacks.onError) activeCallbacks.onError(message);
+    });
+}
+
+/**
+ * Reports whether in-app BitTorrent downloading is supported in this runtime
+ * @returns {Boolean} True if a torrent backend is available
+ */
+function isAvailable () {
+    return !!backend;
+}
+
+/**
+ * Starts (or resumes) a torrent download; a partial file from an earlier attempt in the same
+ * folder is verified and completed rather than restarted
+ * @param {String} torrentUrl The URL of the .torrent file (Kiwix torrents include web seeds)
+ * @param {String} savePath The absolute path of the directory to save the archive in
+ * @param {Object} callbacks An object with optional keys onProgress, onDone (both receive a
+ *   status object) and onError (receives an error message string)
+ * @returns {Promise<Object>} A Promise for the initial torrent status ({ infoHash, name,
+ *   total, ... }), rejected with an Error if the torrent could not be started
+ */
+function start (torrentUrl, savePath, callbacks) {
+    activeCallbacks = callbacks || null;
+    return window.electronAPI.startTorrentDownload({
+        torrentUrl: torrentUrl,
+        savePath: savePath
+    }).then(function (result) {
+        if (!result.ok) {
+            activeCallbacks = null;
+            throw new Error(result.error);
+        }
+        return result.status;
+    });
+}
+
+/**
+ * Stops a torrent: cancels a download in progress, or stops seeding a completed one
+ * @param {String} infoHash The infoHash of the torrent (from the status object)
+ * @param {Boolean} deletePartial Whether to delete the partial file (pass false to allow
+ *   a later download of the same archive to resume from it)
+ * @returns {Promise<Boolean>} A Promise resolving true if a torrent was found and stopped
+ */
+function stop (infoHash, deletePartial) {
+    activeCallbacks = null;
+    return window.electronAPI.stopTorrentDownload(infoHash, deletePartial);
+}
+
+/**
+ * Gets the status of one torrent, or an array of statuses of all torrents if no infoHash given
+ * @param {String} infoHash Optional infoHash of a specific torrent
+ * @returns {Promise<Object|Array|null>} A Promise for the status
+ */
+function getStatus (infoHash) {
+    return window.electronAPI.getTorrentStatus(infoHash);
+}
+
+/**
+ * Sets whether completed torrents keep seeding until the app quits; turning this off also
+ * stops any torrent that is currently seeding
+ * @param {Boolean} value Whether to keep seeding completed torrents
+ */
+function setSeeding (value) {
+    if (backend === 'electron') window.electronAPI.setTorrentSeeding(value);
+}
+
+export default {
+    isAvailable: isAvailable,
+    start: start,
+    stop: stop,
+    getStatus: getStatus,
+    setSeeding: setSeeding
+};

--- a/www/js/lib/torrentClient.js
+++ b/www/js/lib/torrentClient.js
@@ -21,24 +21,56 @@
 
 import settingsStore from './settingsStore.js';
 
-// The callbacks of the currently active download ({ onProgress, onDone, onError } or null).
-// The UI only starts one torrent at a time, so a single set of callbacks is sufficient.
-var activeCallbacks = null;
+// The callbacks of each download ({ onProgress, onDone, onError }), keyed by the torrent's
+// infoHash. A key holding null is a detached torrent (e.g. one left seeding after the UI has
+// moved on to a new download): its events are deliberately dropped, so that they cannot
+// interfere with the status reporting of the current download.
+var downloadCallbacks = {};
+
+// Events cannot be routed until start() resolves with the torrent's infoHash, but a torrent
+// that is already complete on disk fires 'done' almost immediately, so events for an unknown
+// infoHash are buffered while a start is in flight and flushed when it settles
+var startInFlight = false;
+var bufferedEvents = [];
 
 // Backend detection: 'electron' via the preload API; NWJS will be added here later
 // (e.g. window.nw && parseInt(nw.process.versions.node) >= 20)
 var backend = window.electronAPI && window.electronAPI.startTorrentDownload ? 'electron' : null;
 
+/**
+ * Routes a torrent event to the callbacks of the torrent it belongs to
+ * @param {String} type The callback name ('onProgress', 'onDone' or 'onError')
+ * @param {String} infoHash The infoHash the event belongs to (may be null for some errors)
+ * @param {Object|String} arg The argument to pass to the callback
+ */
+function dispatchEvent (type, infoHash, arg) {
+    if (infoHash && infoHash in downloadCallbacks) {
+        var callbacks = downloadCallbacks[infoHash];
+        if (callbacks && callbacks[type]) callbacks[type](arg);
+    } else if (startInFlight) {
+        bufferedEvents.push({ type: type, infoHash: infoHash, arg: arg });
+    } else if (!infoHash && type === 'onError') {
+        // An error that could not be attributed to a torrent: report it to all downloads
+        Object.keys(downloadCallbacks).forEach(function (hash) {
+            var callbacks = downloadCallbacks[hash];
+            if (callbacks && callbacks.onError) callbacks.onError(arg);
+        });
+    }
+}
+
 if (backend === 'electron') {
-    // Register the IPC event listeners once; they dispatch to whichever download is active
+    // Register the IPC event listeners once; each event is routed by infoHash
     window.electronAPI.on('torrent-progress', function (status) {
-        if (activeCallbacks && activeCallbacks.onProgress) activeCallbacks.onProgress(status);
+        dispatchEvent('onProgress', status.infoHash, status);
     });
     window.electronAPI.on('torrent-done', function (status) {
-        if (activeCallbacks && activeCallbacks.onDone) activeCallbacks.onDone(status);
+        dispatchEvent('onDone', status.infoHash, status);
     });
-    window.electronAPI.on('torrent-error', function (message) {
-        if (activeCallbacks && activeCallbacks.onError) activeCallbacks.onError(message);
+    window.electronAPI.on('torrent-error', function (payload) {
+        // Errors are sent as { infoHash, message }; infoHash is null if the torrent failed
+        // before it was registered
+        var message = payload && payload.message ? payload.message : String(payload);
+        dispatchEvent('onError', payload && payload.infoHash, message);
     });
 }
 
@@ -61,16 +93,27 @@ function isAvailable () {
  *   total, ... }), rejected with an Error if the torrent could not be started
  */
 function start (torrentUrl, savePath, callbacks) {
-    activeCallbacks = callbacks || null;
+    startInFlight = true;
     return window.electronAPI.startTorrentDownload({
         torrentUrl: torrentUrl,
         savePath: savePath
     }).then(function (result) {
-        if (!result.ok) {
-            activeCallbacks = null;
-            throw new Error(result.error);
-        }
+        startInFlight = false;
+        var buffered = bufferedEvents;
+        bufferedEvents = [];
+        if (!result.ok) throw new Error(result.error);
+        downloadCallbacks[result.status.infoHash] = callbacks || null;
+        // Deliver any events for this torrent that arrived before its infoHash was known
+        buffered.forEach(function (event) {
+            if (event.infoHash === result.status.infoHash || (!event.infoHash && event.type === 'onError')) {
+                dispatchEvent(event.type, result.status.infoHash, event.arg);
+            }
+        });
         return result.status;
+    }, function (err) {
+        startInFlight = false;
+        bufferedEvents = [];
+        throw err;
     });
 }
 
@@ -82,8 +125,18 @@ function start (torrentUrl, savePath, callbacks) {
  * @returns {Promise<Boolean>} A Promise resolving true if a torrent was found and stopped
  */
 function stop (infoHash, deletePartial) {
-    activeCallbacks = null;
+    detach(infoHash);
     return window.electronAPI.stopTorrentDownload(infoHash, deletePartial);
+}
+
+/**
+ * Detaches the callbacks of a torrent so that its further events are silently dropped;
+ * the torrent itself is unaffected (used to leave a completed torrent seeding in the
+ * background without it writing over the status reports of a newer download)
+ * @param {String} infoHash The infoHash of the torrent to detach
+ */
+function detach (infoHash) {
+    if (infoHash) downloadCallbacks[infoHash] = null;
 }
 
 /**
@@ -165,6 +218,7 @@ export default {
     isAvailable: isAvailable,
     start: start,
     stop: stop,
+    detach: detach,
     getStatus: getStatus,
     setSeeding: setSeeding,
     resolveSavePath: resolveSavePath

--- a/www/js/lib/torrentClient.js
+++ b/www/js/lib/torrentClient.js
@@ -149,6 +149,21 @@ function getStatus (infoHash) {
 }
 
 /**
+ * Deletes an abandoned partial download from disk (used when the user discards a download
+ * that was left in progress when the app was last closed, rather than resuming it)
+ * @param {String} savePath The directory the torrent was downloading into
+ * @param {String} name The torrent's name (i.e. the downloaded file's name)
+ * @returns {Promise<Boolean>} A Promise resolving true if a file was found and deleted
+ */
+function deletePartial (savePath, name) {
+    if (backend !== 'electron') return Promise.resolve(false);
+    return window.electronAPI.deletePartialTorrentFile(savePath, name).then(function (result) {
+        if (!result.ok) throw new Error(result.error);
+        return result.deleted;
+    });
+}
+
+/**
  * Sets whether completed torrents keep seeding until the app quits; turning this off also
  * stops any torrent that is currently seeding
  * @param {Boolean} value Whether to keep seeding completed torrents
@@ -221,5 +236,6 @@ export default {
     detach: detach,
     getStatus: getStatus,
     setSeeding: setSeeding,
-    resolveSavePath: resolveSavePath
+    resolveSavePath: resolveSavePath,
+    deletePartial: deletePartial
 };

--- a/www/js/lib/torrentClient.js
+++ b/www/js/lib/torrentClient.js
@@ -95,6 +95,7 @@ function isAvailable () {
  *   total, ... }), rejected with an Error if the torrent could not be started
  */
 function start (torrentUrl, savePath, callbacks) {
+    if (backend !== 'electron') return Promise.reject(new Error('In-app BitTorrent downloading is not available in this runtime'));
     startInFlight = true;
     return window.electronAPI.startTorrentDownload({
         torrentUrl: torrentUrl,
@@ -127,6 +128,7 @@ function start (torrentUrl, savePath, callbacks) {
  * @returns {Promise<Boolean>} A Promise resolving true if a torrent was found and stopped
  */
 function stop (infoHash, deletePartial) {
+    if (backend !== 'electron') return Promise.resolve(false);
     detach(infoHash);
     return window.electronAPI.stopTorrentDownload(infoHash, deletePartial);
 }
@@ -147,6 +149,7 @@ function detach (infoHash) {
  * @returns {Promise<Object|Array|null>} A Promise for the status
  */
 function getStatus (infoHash) {
+    if (backend !== 'electron') return Promise.resolve(null);
     return window.electronAPI.getTorrentStatus(infoHash);
 }
 


### PR DESCRIPTION
Fixes #877. This uses WebTorrent under NodeJS, so that it can interact with the full BitTorrent protocol, rather than just the WebRTC hosts that are supported under plain JS: This means that only Electron and NWJS packages will leverage BitTorrent downloading.