### PR TITLE
Reload current article immediately when switching content injection mode

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1846,7 +1846,17 @@ document.querySelectorAll('input[name="contentInjectionMode"][type="radio"]').fo
                 }
             }
         }
-        params.themeChanged = true; // This will reload the page
+        // Reload the currently displayed article straight away, so that anchor click handling
+        // (which differs between Restricted and Service Worker mode) is applied to the page that
+        // is already open, instead of only taking effect on the next navigation
+        if (appstate.selectedArchive && appstate.selectedArchive.isReady()) {
+            if (params.lastPageVisit) {
+                goToArticle(params.lastPageVisit.replace(/@[^@].+$/, ''));
+            } else {
+                goToMainArticle();
+            }
+        }
+        params.themeChanged = false;
     });
 });
 document.getElementById('allowInternetAccessCheck').addEventListener('change', function () {


### PR DESCRIPTION
## Summary

Fixes #601.

When switching between Restricted (jQuery) mode and Service Worker mode from Configuration, the change handler only set `params.themeChanged = true`, which meant the currently displayed article kept the anchor click-handling behaviour of the *previous* mode. Because of this, some links in an already-open article would open in a new tab even after switching modes. The stale behaviour was only corrected once the user navigated to another page/article (which consumes the `themeChanged` flag in `setTab`) or restarted the app.

## Fix

The content-injection-mode change handler now reloads the currently displayed article immediately after the mode switch, reusing the same reload logic already used elsewhere in the app (reload `params.lastPageVisit` if there is one, otherwise go to the main article). This only runs when an archive is actually loaded and ready, so it has no effect on the welcome screen. `themeChanged` is set to `false` afterwards since the reload has already happened, so a later navigation won't reload a second time.

## Test plan

- [ ] Open an article in Restricted mode, switch to Service Worker mode from Configuration, and confirm links in the article open correctly without needing to navigate away first
- [ ] Open an article in Service Worker mode, switch to Restricted mode, and confirm the same
- [ ] Switch modes with no archive loaded (welcome screen) and confirm no errors occur
- [ ] Switch modes, then use the top navigation as before, and confirm the article isn't reloaded a second time unnecessarily