### PR TITLE
Enable popovers when reading zim with libzim backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * FIX: Popover previews of Wikimedia article links now work when reading the archive with the experimental libzim reader
 * FIX: The popover's open-in-new-window icon now opens a new window or tab when reading with the experimental libzim reader, instead of loading the article in place
 * FIX: Opening an article in a new window or tab no longer blanks or hides the article you were reading in the original window
+* FIX: Zimit (classic) archives read with the experimental libzim reader no longer sometimes stay hidden after a page loads
+* FIX: The last-visited page is now remembered correctly when reading with the experimental libzim reader
 * REGRESSION: Restored the top navigation bar's adaptation to the window controls overlay, which was lost in the Bootstrap 4 migration (latest browsers turn the overlay on by default, so the window buttons were covering the app's controls)
 * REGRESSION: Restored the draggable area in the top navigation bar, which was lost in the Bootstrap 4 migration, so the app window can be moved again when the window controls overlay is shown
 * REGRESSION: Fix non-responsive links formatted as headings in Zimit archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * FIX: The library's Language, Subject and Date filters now apply instantly, without rebuilding the list, and no longer reset when returning to the list
 * FIX: Auto-updates now enabled for the macOS Electron app
 * FIX: The colour of the window frame now follows the app's navigation bar, so the window buttons no longer sit in a contrasting block in light mode
+* FIX: Popover previews of Wikimedia article links now work when reading the archive with the experimental libzim reader
 * REGRESSION: Restored the top navigation bar's adaptation to the window controls overlay, which was lost in the Bootstrap 4 migration (latest browsers turn the overlay on by default, so the window buttons were covering the app's controls)
 * REGRESSION: Restored the draggable area in the top navigation bar, which was lost in the Bootstrap 4 migration, so the app window can be moved again when the window controls overlay is shown
 * REGRESSION: Fix non-responsive links formatted as headings in Zimit archives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * FIX: Auto-updates now enabled for the macOS Electron app
 * FIX: The colour of the window frame now follows the app's navigation bar, so the window buttons no longer sit in a contrasting block in light mode
 * FIX: Popover previews of Wikimedia article links now work when reading the archive with the experimental libzim reader
+* FIX: The popover's open-in-new-window icon now opens a new window or tab when reading with the experimental libzim reader, instead of loading the article in place
+* FIX: Opening an article in a new window or tab no longer blanks or hides the article you were reading in the original window
 * REGRESSION: Restored the top navigation bar's adaptation to the window controls overlay, which was lost in the Bootstrap 4 migration (latest browsers turn the overlay on by default, so the window buttons were covering the app's controls)
 * REGRESSION: Restored the draggable area in the top navigation bar, which was lost in the Bootstrap 4 migration, so the app window can be moved again when the window controls overlay is shown
 * REGRESSION: Fix non-responsive links formatted as headings in Zimit archives

--- a/service-worker.js
+++ b/service-worker.js
@@ -428,7 +428,7 @@ self.addEventListener('fetch', function (event) {
                         });
                     }
                     const range = modRequestOrResponse.headers.get('range');
-                    return fetchUrlFromZIM(urlObject, range).then(function (response) {
+                    return fetchUrlFromZIM(urlObject, range, event).then(function (response) {
                         return cacheAndReturnResponseForAsset(event, response);
                     }).catch(function (msgPortData) {
                         console.error('Invalid message received from app.js for ' + strippedUrl, msgPortData);
@@ -597,7 +597,7 @@ function zimitResolver (event, rqUrl) {
         console.debug('[SW] Filtering content of load.js', rqUrl);
         // First we have to get the contents of load.js from the ZIM, because it is a common name, and there is no way to be sure
         // that the request will be for the Zimit load.js
-        return fetchUrlFromZIM(new URL(rqUrl)).then(function (response) {
+        return fetchUrlFromZIM(new URL(rqUrl), null, event).then(function (response) {
             // The response was found in the ZIM so we respond with it
             // Clone the response before reading its body
             var clonedResponse = response.clone();
@@ -713,17 +713,28 @@ function fetchUrlFromZIM (urlObjectOrString, range, event/*, expectedHeaders */)
 
         // console.debug('[SW] Asking app.js for ' + titleWithNameSpace + ' from ' + zimName + '...');
 
-        // Get the requesting client's frameType if available
-        // This tells us whether the fetch request came from an iframe ('nested'), a top-level window ('top-level'),
-        // or another context. We pass this info to the app so it knows whether to hide the articleContainer
-        // to prevent theme flash (only needed for its own iframe, not for new windows/tabs users open).
-        var getRequestingFrameType = event && event.clientId
-            ? self.clients.get(event.clientId).then(function (client) {
+        // Establish whether the fetch request came from an iframe ('nested'), a top-level window or tab ('top-level'),
+        // or an indeterminate context ('unknown'). We pass this info to the app so that it knows whether the content is
+        // destined for its own iframe: it must not manipulate that iframe on behalf of a window the user opened separately.
+        // DEV: We cannot simply look the requesting client up by event.clientId, because for navigation requests (which is
+        // what an article load is) the clientId is empty -- the client does not exist yet. The request destination tells us
+        // what we need synchronously, so we use that first, and fall back to the client lookup, which does work for
+        // subresource requests. Engines that support neither will report 'unknown', which the app treats as it always has.
+        var destination = event && event.request ? event.request.destination : '';
+        var getRequestingFrameType;
+        if (/^i?frame$/.test(destination)) {
+            getRequestingFrameType = Promise.resolve('nested');
+        } else if (destination === 'document') {
+            getRequestingFrameType = Promise.resolve('top-level');
+        } else if (event && event.clientId) {
+            getRequestingFrameType = self.clients.get(event.clientId).then(function (client) {
                 return client ? client.frameType : 'unknown';
             }).catch(function () {
                 return 'unknown';
-            })
-            : Promise.resolve('unknown');
+            });
+        } else {
+            getRequestingFrameType = Promise.resolve('unknown');
+        }
 
         var messageListener = function (msgPortEvent) {
             if (msgPortEvent.data.action === 'giveContent') {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5974,9 +5974,14 @@ function filterClickEvent (event) {
             // @TODO - may not be necessary because params.lastPageVisit is only set when HTML is loaded
         } else {
             var decHref = decodeURIComponent(href);
-            // Establish whether this click is destined for a new window or tab, either because the user requested one with a
-            // modifier key or middle-click, or because the popover's break-out icon set the newcontainer property on the anchor
-            var opensNewContainer = clickedAnchor.newcontainer || event.ctrlKey || event.metaKey || event.shiftKey || event.button === 1;
+            // Establish whether this click is destined for a new window or tab, either because the anchor targets another
+            // browsing context, or because the user requested one with a modifier key or middle-click, or because the
+            // popover's break-out icon set the newcontainer property on the anchor
+            // DEV: _self, _parent and _top all stay within the current window, but any other target names a different
+            // browsing context, which the browser will open as a new window or tab unless a frame of that name exists
+            var anchorTarget = clickedAnchor.target;
+            var opensNewContainer = clickedAnchor.newcontainer || event.ctrlKey || event.metaKey || event.shiftKey ||
+                event.button === 1 || (anchorTarget && !/^_(self|parent|top)$/i.test(anchorTarget));
             // With the libzim backend, addListenersToLink does not run, so nothing actions the break-out icon's request for a
             // new container: we do it here. No further window management is needed, because the ServiceWorker asks this
             // instance for the content of the new window in any case [kiwix-js-pwa #912]
@@ -6520,7 +6525,11 @@ function handleMessageChannelForLibzim (event) {
             // We have to prevent a null load event from firing, or else we get CORS errors blocking the app
             // loaded = true;
         } else {
-            dirEntry.url = title.replace(/^[-ABCHIJMUVWX]\//, '');
+            // DEV: The libzim worker returns the full path, but the rest of the app expects a dirEntry to carry the namespace
+            // and the url separately, and reconstructs the path as namespace + '/' + url (e.g. to store the last-visited page)
+            var pathParts = title.match(/^([-ABCHIJMUVWX])\/(.*)$/);
+            dirEntry.namespace = pathParts ? pathParts[1] : '';
+            dirEntry.url = pathParts ? pathParts[2] : title;
             // DEV: Unlike with custom backend, libzim dirEntries contain a mimetype string rather than a function
             var message = { action: 'giveContent', title: title, content: dirEntry.content, mimetype: dirEntry.mimetype, origin: 'libzim' };
             // The ServiceWorker broadcasts its request to every window controlled by this app, so the content we are serving

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -6161,6 +6161,9 @@ var articleLoadedSW = function (dirEntry, container) {
         if (appstate.wikimediaZimLoaded && params.showPopoverPreviews) {
             var darkTheme = (params.cssUITheme == 'auto' ? cssUIThemeGetOrSet('auto', true) : params.cssUITheme) !== 'light';
             popovers.attachKiwixPopoverCss(doc, darkTheme);
+            // With the libzim backend we do not run parseAnchorsJQuery (see above), so no popover listeners are attached to
+            // individual anchors: instead we attach delegated listeners to the article window [kiwix-js #1336]
+            if (params.useLibzim) attachPopoverTriggerEvents(articleWindow);
         }
         params.isLandingPage = false;
     } else if (unhideArticleTries > 0) {
@@ -6180,6 +6183,117 @@ var articleLoadedSW = function (dirEntry, container) {
         }
     };
 };
+
+/**
+ * Attaches delegated popover trigger events to the given window
+ * DEV: This is only used with the libzim backend, because with the custom backend the equivalent listeners are attached
+ * to each anchor individually in addListenersToLink (which additionally handles link interception and window opening)
+ * @param {Window} win The window to which to attach popover trigger events
+ */
+function attachPopoverTriggerEvents (win) {
+    // The popover feature requires as a minimum that the browser supports the css matches function
+    // (having this condition prevents very erratic popover placement in IE11, for example, so the feature is disabled for such browsers)
+    if (!win || !win.document || !appstate.wikimediaZimLoaded || !params.showPopoverPreviews || !('matches' in Element.prototype)) {
+        return;
+    }
+    // Add event listeners to the article window to check when anchors are hovered, focused or touched
+    // DEV: Duplicate registrations of the same function reference are ignored by the browser, so these are safe to re-attach
+    win.addEventListener('mouseover', evokePopoverEvents, true);
+    win.addEventListener('focus', evokePopoverEvents, true);
+    // Conditionally add event listeners to support touch events with fallback to pointer events
+    if (window.navigator.maxTouchPoints > 0) {
+        win.addEventListener('touchstart', evokePopoverEvents, true);
+    } else {
+        win.addEventListener('pointerdown', evokePopoverEvents, true);
+    }
+}
+
+// Throttle for the popover event handler to prevent multiple activations with mouse movement
+var popoverThrottle = false;
+
+/**
+ * Conditionally evokes popover events subject to a throttle
+ * @param {Event} event The event produced by the calling action
+ */
+function evokePopoverEvents (event) {
+    // Check if the hovered or focused element or its parent is a link
+    if (popoverThrottle) return;
+    popoverThrottle = true;
+    setTimeout(function () {
+        handlePopoverEvents(event);
+        popoverThrottle = false;
+    }, 10);
+};
+
+/**
+ * Event handler for attaching preview popovers
+ * @param {Event} ev The event produced by the mouseover, focus, touchstart or pointerdown action
+ */
+function handlePopoverEvents (ev) {
+    var anchor = ev.target;
+    var articleDoc = anchor.ownerDocument;
+    if (!articleDoc) return;
+    var win = articleDoc.defaultView;
+    while (anchor && anchor !== win && anchor.nodeName !== 'A') {
+        anchor = anchor.parentNode;
+    }
+    // If we're not hovering a link, then we can exit
+    if (!anchor || anchor.nodeName !== 'A') return;
+    var suppressContextMenuHandler = function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+    };
+    // Prevent context menu on this anchor element
+    anchor.addEventListener('contextmenu', suppressContextMenuHandler, true);
+    if (/touchstart|pointerdown/.test(ev.type)) {
+        anchor.touched = true; // Used to prevent dismissal of popover on mouseout if initiated by touch
+    }
+    if (anchor.style.userSelect === undefined) {
+        // This prevents selection of the text in a touched link in Safari for iOS and Edge Legacy / UWP
+        anchor.style.webkitUserSelect = 'none';
+        anchor.style.msUserSelect = 'none';
+    }
+    // Check if a popover div is currently being hovered
+    var divArray = Array.prototype.slice.call(articleDoc.getElementsByClassName('kiwixtooltip'));
+    var divIsHovered = divArray.some(function (div) {
+        return div.matches(':hover');
+    });
+    // Only add a popover to the link if a current popover is not being hovered (prevents popovers showing for links in a popover)
+    if (!divIsHovered) {
+        // Prevent text selection while popover is open in modern browsers
+        anchor.style.userSelect = 'none';
+        var darkTheme = (params.cssUITheme == 'auto' ? cssUIThemeGetOrSet('auto', true) : params.cssUITheme) !== 'light';
+        // Get and populate the popover corresponding to the hovered or focused link
+        popovers.populateKiwixPopoverDiv(ev, anchor, appstate, darkTheme, appstate.selectedArchive);
+    }
+    var outHandler = function (e) {
+        setTimeout(function () {
+            anchor.popoverisloading = false;
+            if (/blur/.test(e.type) || !anchor.touched) {
+                popovers.removeKiwixPopoverDivs(articleDoc);
+                anchor.touched = false;
+            }
+            anchor.style.webkitUserSelect = 'auto';
+            anchor.style.msUserSelect = 'auto';
+            anchor.style.userSelect = 'auto';
+            anchor.removeEventListener(e.type, outHandler);
+            anchor.removeEventListener('contextmenu', suppressContextMenuHandler, true);
+        }, 250);
+    };
+    // Clean up when user stops hovering, lifts pointer, stops touching, or unfocuses (blurs) the link
+    if (/mouseover/.test(ev.type)) {
+        anchor.addEventListener('mouseleave', outHandler);
+    }
+    if (/pointerdown/.test(ev.type)) {
+        anchor.addEventListener('pointerup', outHandler);
+    }
+    if (/touchstart/.test(ev.type)) {
+        anchor.addEventListener('touchend', outHandler);
+    }
+    if (ev.type === 'focus') {
+        anchor.addEventListener('blur', outHandler);
+    }
+}
 
 // Handles a click on a Zimit link that has been processed by Wombat
 function handleClickOnReplayLink (ev, anchor) {
@@ -6392,6 +6506,10 @@ function handleMessageChannelForLibzim (event) {
             // DEV: Unlike with custom backend, libzim dirEntries contain a mimetype string rather than a function
             var message = { action: 'giveContent', title: title, content: dirEntry.content, mimetype: dirEntry.mimetype, origin: 'libzim' };
             if (/\bx?html\b/i.test(dirEntry.mimetype) && !dirEntry.isAsset) {
+                // Update appstate for HTML content, so that link-based navigation is tracked correctly (this is done by
+                // addListenersToLink and readArticle with the custom backend, neither of which runs in libzim mode) [kiwix-js #1385]
+                appstate.baseUrl = encodeURI(title.replace(/[^/]+$/, ''));
+                appstate.expectedArticleURLToBeDisplayed = title;
                 if (articleContainer.kiwixType === 'iframe') articleContainer.style.display = 'none';
                 articleContainer.onload = function () {
                     // if (loaded) return;

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -6076,7 +6076,8 @@ var articleLoadedSW = function (dirEntry, container) {
     uiUtil.showSlidingUIElements();
     var doc = articleWindow ? articleWindow.document : null;
     articleDocument = articleWindow.document.documentElement;
-    var mimeType = params.useLibzim ? dirEntry.mimeType : dirEntry.getMimetype();
+    // DEV: libzim dirEntries carry a mimetype string (note the lowercase 't', as returned by the libzim worker) rather than a function
+    var mimeType = params.useLibzim ? dirEntry.mimetype : dirEntry.getMimetype();
     // If we've successfully loaded an HTML document...
     if (doc && /\bx?html/i.test(mimeType)) {
         // console.debug('HTML appears to be available...');
@@ -6526,23 +6527,39 @@ function handleMessageChannelForLibzim (event) {
             // may well be destined for a window or tab the user opened separately. In that case we must neither track it as
             // our own state nor touch our iframe, or we blank the article the user is still reading [kiwix-js-pwa #572]
             var contentIsForThisIframe = event.data.requestingFrameType !== 'top-level';
+            // DEV: Do not be tempted to exclude the legacy Zimit fallback here (by testing appstate.isReplayWorkerAvailable):
+            // reading a Zimit (classic) archive with the legacy method and the libzim backend loops whatever we do here, and
+            // routing it back to the inline handler below additionally locks the UI, so the Configuration panel cannot be
+            // opened to turn the legacy method off again
+            var isZimitClassic = appstate.selectedArchive.zimType === 'zimit';
             if (/\bx?html\b/i.test(dirEntry.mimetype) && !dirEntry.isAsset && contentIsForThisIframe) {
                 // Update appstate for HTML content, so that link-based navigation is tracked correctly (this is done by
                 // addListenersToLink and readArticle with the custom backend, neither of which runs in libzim mode) [kiwix-js #1385]
                 appstate.baseUrl = encodeURI(title.replace(/[^/]+$/, ''));
                 appstate.expectedArticleURLToBeDisplayed = title;
-                if (articleContainer.kiwixType === 'iframe') articleContainer.style.display = 'none';
-                articleContainer.onload = function () {
-                    // if (loaded) return;
-                    // articleContainer.style.display = '';
-                    // resizeIFrame();
-                    // // Trap clicks in the iframe to enable us to work around the sandbox when opening external links and PDFs
-                    // articleWindow.removeEventListener('click', filterClickEvent, true);
-                    // articleWindow.addEventListener('click', filterClickEvent, true);
-                    articleLoadedSW(dirEntry, articleContainer);
-                };
+                // For Zimit (classic) the article is not displayed in this container at all, but in the replay_iframe nested
+                // inside it, so we leave the display and the load handling to articleLoader below
+                if (!isZimitClassic) {
+                    if (articleContainer.kiwixType === 'iframe') articleContainer.style.display = 'none';
+                    articleContainer.onload = function () {
+                        // if (loaded) return;
+                        // articleContainer.style.display = '';
+                        // resizeIFrame();
+                        // // Trap clicks in the iframe to enable us to work around the sandbox when opening external links and PDFs
+                        // articleWindow.removeEventListener('click', filterClickEvent, true);
+                        // articleWindow.addEventListener('click', filterClickEvent, true);
+                        articleLoadedSW(dirEntry, articleContainer);
+                    };
+                }
             }
             messagePort.postMessage(message);
+            // With Zimit (classic) archives, it is articleLoader that attaches the load handling to the nested replay_iframe,
+            // and that unhides that iframe and the sliding UI elements once the replay document has settled. It has to be called
+            // for every entry, because comparing the replay document's location is how it detects that the document has navigated.
+            // The custom backend does this from handleMessageChannelMessage; nothing did so in libzim mode [kiwix-js #1380]
+            if (isZimitClassic && contentIsForThisIframe) {
+                articleLoader(dirEntry, dirEntry.mimetype);
+            }
         }
     }).catch(function () {
         messagePort.postMessage({ action: 'giveContent', title: title, content: new Uint8Array() });

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5974,10 +5974,27 @@ function filterClickEvent (event) {
             // @TODO - may not be necessary because params.lastPageVisit is only set when HTML is loaded
         } else {
             var decHref = decodeURIComponent(href);
+            // Establish whether this click is destined for a new window or tab, either because the user requested one with a
+            // modifier key or middle-click, or because the popover's break-out icon set the newcontainer property on the anchor
+            var opensNewContainer = clickedAnchor.newcontainer || event.ctrlKey || event.metaKey || event.shiftKey || event.button === 1;
+            // With the libzim backend, addListenersToLink does not run, so nothing actions the break-out icon's request for a
+            // new container: we do it here. No further window management is needed, because the ServiceWorker asks this
+            // instance for the content of the new window in any case [kiwix-js-pwa #912]
+            if (params.useLibzim && clickedAnchor.newcontainer && params.windowOpener) {
+                event.preventDefault();
+                event.stopPropagation();
+                clickedAnchor.newcontainer = false;
+                console.debug('filterClickEvent opening new ' + params.windowOpener + ' for ' + decHref);
+                window.open(clickedAnchor.href, params.windowOpener === 'tab' ? '_blank' : clickedAnchor.title,
+                    params.windowOpener === 'window' ? 'toolbar=0,location=0,menubar=0,width=800,height=600,resizable=1,scrollbars=1' : null);
+                return;
+            }
             // We need to ensure that the link we wish to load is not already loaded in the article container, to handle links which are to the same document
             // e.g., those containing fragments at the end of a relative URL, or those containing querystrings
             var zimURL = uiUtil.deriveZimUrlFromRelativeUrl(href, appstate.expectedArticleURLToBeDisplayed);
-            if (zimURL !== appstate.expectedArticleURLToBeDisplayed && !/^(?:#|javascript|null)/i.test(decHref)) {
+            // Note that if the article is opening in a new window or tab, the current document stays where it is, so we must
+            // neither tear it down nor show a spinner for a load that will not happen here [kiwix-js-pwa #572]
+            if (!opensNewContainer && zimURL !== appstate.expectedArticleURLToBeDisplayed && !/^(?:#|javascript|null)/i.test(decHref)) {
                 uiUtil.pollSpinner('Loading ' + decHref.replace(/([^/]+)$/, '$1').substring(0, 18) + '...');
                 // Tear down contents of previous document -- this is needed when a link in a ZIM link in an external window hasn't had
                 // an event listener attached. For example, links in popovers in external windows. UWP doesn't allow access to the contents
@@ -6505,7 +6522,11 @@ function handleMessageChannelForLibzim (event) {
             dirEntry.url = title.replace(/^[-ABCHIJMUVWX]\//, '');
             // DEV: Unlike with custom backend, libzim dirEntries contain a mimetype string rather than a function
             var message = { action: 'giveContent', title: title, content: dirEntry.content, mimetype: dirEntry.mimetype, origin: 'libzim' };
-            if (/\bx?html\b/i.test(dirEntry.mimetype) && !dirEntry.isAsset) {
+            // The ServiceWorker broadcasts its request to every window controlled by this app, so the content we are serving
+            // may well be destined for a window or tab the user opened separately. In that case we must neither track it as
+            // our own state nor touch our iframe, or we blank the article the user is still reading [kiwix-js-pwa #572]
+            var contentIsForThisIframe = event.data.requestingFrameType !== 'top-level';
+            if (/\bx?html\b/i.test(dirEntry.mimetype) && !dirEntry.isAsset && contentIsForThisIframe) {
                 // Update appstate for HTML content, so that link-based navigation is tracked correctly (this is done by
                 // addListenersToLink and readArticle with the custom backend, neither of which runs in libzim mode) [kiwix-js #1385]
                 appstate.baseUrl = encodeURI(title.replace(/[^/]+$/, ''));

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -26,6 +26,11 @@
 
 import uiUtil from './uiUtil.js';
 
+// Regex to extract the ZIM-internal path after the ZIM file extension (including split ZIMs like .zimaa, .zimab, etc.)
+const regexpZimPath = /\.zim\w?\w?\/(.*)$/i;
+// Regex to detect ZIM URLs with valid namespace
+const regexpZIMUrlWithNamespace = /^[-ABCIJMUVWX]\//;
+
 /**
  * Parses a linked article in a loaded document in order to extract the first main paragraph (the 'lede') and first
  * main image (if any). This function currently only parses Wikimedia articles. It returns an HTML string, formatted
@@ -38,42 +43,53 @@ import uiUtil from './uiUtil.js';
  */
 function getArticleLede (href, baseUrl, articleDocument, archive) {
     const uriComponent = uiUtil.removeUrlParameters(href);
+
+    // Check if we're using libzim backend
+    if (params.useLibzim) {
+        // Extract ZIM-internal path from absolute URL like /path/to/file.zim/C/Article
+        let zimURL;
+
+        // Check if href is an absolute URL containing the ZIM file path
+        const zimPathMatch = href.match(regexpZimPath);
+        if (zimPathMatch && zimPathMatch[1]) {
+            zimURL = zimPathMatch[1];
+            zimURL = zimURL.replace(/[?#].*$/, '');
+            zimURL = decodeURIComponent(zimURL);
+        } else {
+            // Handle relative URLs by resolving against current article's path
+            const currentLocation = articleDocument.location.href;
+            let currentZimPath = '';
+
+            const currentPathMatch = currentLocation.match(regexpZimPath);
+            if (currentPathMatch && currentPathMatch[1]) {
+                currentZimPath = currentPathMatch[1];
+                currentZimPath = currentZimPath.replace(/[?#].*$/, '');
+                currentZimPath = decodeURIComponent(currentZimPath);
+            }
+
+            const baseZimPath = currentZimPath.replace(/[^/]+$/, '');
+            zimURL = uiUtil.deriveZimUrlFromRelativeUrl(uriComponent, baseZimPath);
+        }
+
+        console.debug('Previewing ' + zimURL + ' (libzim)');
+        return getArticleLedeWithLibzim(zimURL, articleDocument, archive);
+    }
+
+    // Standard backend - use the provided baseUrl
     const zimURL = uiUtil.deriveZimUrlFromRelativeUrl(uriComponent, baseUrl);
     console.debug('Previewing ' + zimURL);
+
     const promiseForArticle = function (dirEntry) {
         // Wrap legacy callback-based code in a Promise
         return new Promise((resolve, reject) => {
             // As we're reading Wikipedia articles, we can assume that they are UTF-8 encoded HTML data
             archive.readUtf8File(dirEntry, function (fileDirEntry, htmlArticle) {
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(htmlArticle, 'text/html');
-                const articleBody = doc.body;
-                if (articleBody) {
-                    // Establish the popup balloon's base URL and the absolute path for calculating the ZIM URL of links and images
-                    const balloonBaseURL = encodeURI(fileDirEntry.namespace + '/' + fileDirEntry.url.replace(/[^/]+$/, ''));
-                    const docUrl = new URL(articleDocument.location.href);
-                    const rootRelativePathPrefix = docUrl.pathname.replace(/([^.]\.zim\w?\w?\/).+$/i, '$1');
-                    // Clean up the lede content
-                    const nonEmptyParagraphs = cleanUpLedeContent(articleBody);
-                    // Concatenate paragraphs to fill the balloon
-                    let balloonString = '';
-                    if (nonEmptyParagraphs.length > 0) {
-                        balloonString = fillBalloonString(nonEmptyParagraphs, balloonBaseURL, rootRelativePathPrefix);
-                    }
-                    // If we have a lede, we can now add an image to the balloon, but only if we are in ServiceWorker mode
-                    if (balloonString && params.contentInjectionMode === 'serviceworker') {
-                        const imageHTML = getImageHTMLFromNode(articleBody, balloonBaseURL, rootRelativePathPrefix);
-                        if (imageHTML) {
-                            balloonString = imageHTML + balloonString;
-                        }
-                    }
-                    if (!balloonString) {
-                        reject(new Error('No article lede or image'));
-                    } else {
-                        resolve(balloonString);
-                    }
-                } else {
-                    reject(new Error('No article body found'));
+                try {
+                    const zimURL = fileDirEntry.namespace + '/' + fileDirEntry.url;
+                    const balloonString = parseArticleContentForBalloon(htmlArticle, zimURL, articleDocument);
+                    resolve(balloonString);
+                } catch (error) {
+                    reject(error);
                 }
             });
         });
@@ -96,6 +112,94 @@ function getArticleLede (href, baseUrl, articleDocument, archive) {
         throw new Error('Could not get Directory Entry for ' + zimURL, err);
     });
 };
+
+/**
+ * Parses a linked article using libzim backend to extract the first main paragraph (the 'lede') and first
+ * main image (if any). This function is used when params.useLibzim is true.
+ * @param {String} zimURL The ZIM URL of the article to preview
+ * @param {Document} articleDocument The DOM of the currently loaded article
+ * @param {ZIMArchive} archive The archive from which to extract the lede
+ * @returns {Promise<String>} A Promise for the linked article's lede HTML including first main image URL if any
+ */
+function getArticleLedeWithLibzim (zimURL, articleDocument, archive) {
+    return archive.callLibzimWorker({
+        action: 'getEntryByPath',
+        path: zimURL,
+        follow: false // Don't follow redirects automatically so we can detect them
+    }).then(function (ret) {
+        // Check if this is a redirect
+        if (ret.isRedirect) {
+            // It's a redirect, get the content from the redirect target
+            let redirectPath = ret.redirectPath;
+
+            // Preserve namespace from original request if redirect path lacks one
+            if (!regexpZIMUrlWithNamespace.test(redirectPath) && zimURL.indexOf('/') !== -1) {
+                const namespace = zimURL.substring(0, zimURL.indexOf('/') + 1);
+                redirectPath = namespace + redirectPath;
+            }
+
+            return archive.callLibzimWorker({
+                action: 'getEntryByPath',
+                path: redirectPath,
+                follow: false
+            }).then(function (finalRet) {
+                if (!finalRet || !finalRet.content) {
+                    throw new Error('No content found for redirect: ' + zimURL);
+                }
+                const htmlArticle = finalRet.content instanceof Uint8Array
+                    ? archive.getUtf8FromData(finalRet.content) : finalRet.content;
+
+                return parseArticleContentForBalloon(htmlArticle, redirectPath, articleDocument);
+            });
+        } else {
+            // No redirect, process the content normally
+            if (!ret || !ret.content) {
+                throw new Error('No content found for ' + zimURL);
+            }
+            const htmlArticle = ret.content instanceof Uint8Array
+                ? archive.getUtf8FromData(ret.content) : ret.content;
+
+            // Use the original zimURL as the path
+            return parseArticleContentForBalloon(htmlArticle, zimURL, articleDocument);
+        }
+    });
+}
+
+// Helper function to parse article content and create balloon
+function parseArticleContentForBalloon (htmlArticle, zimURL, articleDocument) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlArticle, 'text/html');
+    const articleBody = doc.body;
+
+    if (articleBody) {
+        // Establish the popup balloon's base URL and the absolute path for calculating the ZIM URL of links and images
+        const balloonBaseURL = encodeURI(zimURL.replace(/[^/]+$/, ''));
+        const docUrl = new URL(articleDocument.location.href);
+        const rootRelativePathPrefix = docUrl.pathname.replace(/([^.]\.zim\w?\w?\/).+$/i, '$1');
+
+        // Clean up the lede content
+        const nonEmptyParagraphs = cleanUpLedeContent(articleBody);
+        // Concatenate paragraphs to fill the balloon
+        let balloonString = '';
+        if (nonEmptyParagraphs.length > 0) {
+            balloonString = fillBalloonString(nonEmptyParagraphs, balloonBaseURL, rootRelativePathPrefix);
+        }
+        // If we have a lede, we can now add an image to the balloon, but only if we are in ServiceWorker mode
+        if (balloonString && params.contentInjectionMode === 'serviceworker') {
+            const imageHTML = getImageHTMLFromNode(articleBody, balloonBaseURL, rootRelativePathPrefix);
+            if (imageHTML) {
+                balloonString = imageHTML + balloonString;
+            }
+        }
+        if (!balloonString) {
+            throw new Error('No article lede or image');
+        } else {
+            return balloonString;
+        }
+    } else {
+        throw new Error('No article body found');
+    }
+}
 
 // Helper function to clean up the lede content
 function cleanUpLedeContent (node) {


### PR DESCRIPTION
Fixes #912.
Fixes #572.

Onport of kiwix/kiwix-js#1377 and kiwix/kiwix-js#1389, plus the adjacent fixes they turned out to require.

### Popovers with the libzim backend

- `popovers.js`: direct port of kiwix/kiwix-js#1377 — libzim branch in `getArticleLede()`, new `getArticleLedeWithLibzim()` and `parseArticleContentForBalloon()`. The custom-backend path is refactored onto the same helper and is behaviourally unchanged.
- `app.js`: port of kiwix/kiwix-js#1389 — `handleMessageChannelForLibzim()` now updates `appstate.baseUrl` and `appstate.expectedArticleURLToBeDisplayed`.
- `app.js`: **structural divergence from upstream.** Upstream attaches popover triggers at window level, so it is backend-agnostic. Here they are attached per anchor in `addListenersToLink()`, reached only via `parseAnchorsJQuery()`, which is deliberately skipped for libzim. Upstream's `attachPopoverTriggerEvents`/`evokePopoverEvents`/`handlePopoverEvents` are therefore ported and used **for the libzim path only**, leaving the custom-backend path untouched.

Deliberate deviations from upstream's code: `String.prototype.includes` → `indexOf` (no polyfill here, and we still target IE11/FxOS); upstream's `determinePopoverColours()` replaced by this repo's existing `darkTheme` expression, as `params.enableContentTheme` and `uiUtil.detectNativeZIMThemeSupport` do not exist here; whitespace normalised for our ESLint config. kiwix/kiwix-js#1391 was **not** ported — we keep the Wikivoyage landing-page suppression, because our custom Wikivoyage landing page has an interactive map.

### Why service-worker.js is in this PR

The popover break-out icon could not open a new window in libzim mode, and fixing that exposed the longer-standing bug in #572: content served for a *separate* window was treated as if destined for this window's iframe, hiding it and re-pointing its `onload`.

Telling the two apart needs the requesting frame type. `service-worker.js` already computed and sent `requestingFrameType`, but it was dead code — e3410562 renamed `fetchUrlFromZIM()`'s third parameter to `event` without updating either call site, so it was permanently `undefined` and every message reported `'unknown'`. This PR passes `event` at both call sites and derives the value from `event.request.destination` first (`clientId` is empty for navigation requests, which is what an article load is), falling back to the original client lookup for subresources. Verified in the console: navigations resolve `nested`/`top-level`, and subresources are correctly attributed per window.

### Also rolled in

- The break-out icon opens a new window/tab in libzim mode, honouring `params.windowOpener`.
- Zimit (classic) read with libzim now routes through `articleLoader()` — upstream kiwix/kiwix-js#1380 — so the nested `replay_iframe` is unhidden reliably. It is called for every entry, as that is how it detects the replay document navigating.
- `articleLoadedSW()` read `dirEntry.mimeType`, but libzim entries carry `mimetype`. It was always `undefined`, which silently broke "remember last page" in libzim mode.

### Known unsupported

Reading a Zimit (classic) archive with the *legacy* method while libzim is enabled loops. This is pre-existing, reproduces on both sides of this change, and is not fixed here; a DEV comment records why the obvious-looking narrowing of that condition must not be applied. Guarding the combination is a separate PR.

### Testing

Wikimedia + libzim (popovers via hover/touch/focus, break-out icon), zimit1 + libzim (dark/darkReader/light), zimit2 + libzim, zimit2 + custom backend, ctrl-click throughout.
