### PR TITLE
 Fix #906: decouple slide-away toolbar from #top

### DIFF
--- a/www/css/app.css
+++ b/www/css/app.css
@@ -171,10 +171,11 @@ div:not(.card.border-success .card-body):not(.alert-message) {
     overflow-wrap: break-word;
 }
 
-/* #wcoTitleBar is held against the top of the window by a transform that cancels the one sliding #top
-   away (see hideSlidingUIElements), so it has to be animated on exactly the same curve over exactly the
-   same time, or it lurches to its offset while the header eases into place and the bar appears to fly */
-#top, #articleContent, #footer, article, #wcoTitleBar {
+/* #navbar .container-fluid is the slide-away target (see hideSlidingUIElements): it slides out from
+   under the title bar rather than taking the whole header with it, so #top and #wcoTitleBar no longer
+   need a coordinated transition. These three elements animate on the same ease so the layout shifts
+   smoothly together */
+#articleContent, #footer, article, #navbar .container-fluid {
     transition: transform 0.5s ease;
 }
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -889,13 +889,10 @@ if (typeof Windows !== 'undefined' &&
 }
 
 document.getElementById('btnTop').addEventListener('click', function () {
-    var header = document.getElementById('top');
     var iframe = document.getElementById('articleContent');
     // If the toolbar is hidden, show it instead of jumping to top
-    if (!/\(0p?x?\)/.test(header.style.transform)) {
-        header.style.transform = 'translateY(0)';
-        // Release the emulated title bar, which hideSlidingUIElements holds down against the header
-        document.getElementById('wcoTitleBar').style.transform = '';
+    if (!appstate.toolbarVisible) {
+        uiUtil.showSlidingUIElements();
     } else {
         if (!params.hideToolbars) iframe.style.transform = 'translateY(-1px)';
         iframe.contentWindow.scrollTo({

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -67,6 +67,11 @@ var params = {};
  */
 var appstate = {};
 
+// Track whether the slide-away toolbars are currently visible. This is the single source of truth for
+// the toolbar visibility state, replacing the previous fragile approach of parsing the header's inline
+// transform string with a regex (see uiUtil.js hideSlidingUIElements/showSlidingUIElements)
+appstate.toolbarVisible = true;
+
 // ******** UPDATE VERSION IN service-worker.js TO MATCH VERSION AND CHECK PWASERVER BELOW!!!!!!! *******
 params['appVersion'] = '3.8.9'; // DEV: Manually update this version when there is a new release: it is compared to the Settings Store "appVersion" in order to show first-time info, and the cookie is updated in app.js
 // ******* UPDATE THIS ^^^^^^ IN service worker AND PWA-SERVER BELOW !! ********************

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -40,6 +40,9 @@ const footer = document.getElementById('footer');
 // browser is drawing the window controls overlay over the app and the user has asked for a title bar of
 // the app's own (see the html.show-titlebar rules in app.css)
 const titleBar = document.getElementById('wcoTitleBar');
+// The inner container that holds the search rows — this is the element that slides away, keeping the
+// title bar and the navbar shell fixed in place (see hideSlidingUIElements / showSlidingUIElements)
+const containerFluid = header.querySelector('.container-fluid');
 let articleContainer = document.getElementById('articleContent');
 
 /**
@@ -50,28 +53,19 @@ function hideSlidingUIElements () {
     const articleElement = document.querySelector('article');
     const footerStyles = getComputedStyle(footer);
     const footerHeight = parseFloat(footerStyles.height) + parseFloat(footerStyles.marginTop) - 2;
-    const headerStyles = getComputedStyle(header);
-    const headerHeight = parseFloat(headerStyles.height) + parseFloat(headerStyles.marginBottom) - 2;
-    // The emulated title bar is the topmost strip of the header, so it is the first thing to leave the
-    // window when the header slides up. Pushing it back down by the same amount holds it against the top
-    // of the window while the search row disappears beneath it: a title bar is window chrome and should
-    // not scroll away, and it is the only part of the app the user can grab to move the window once the
-    // toolbars have gone. It cannot be pinned in CSS instead, because sticky positioning needs a
-    // scrollport (nothing here scrolls, the header is transformed) and a fixed child of a transformed
-    // ancestor is positioned against that ancestor, so it would travel with the header regardless
     const titleBarHeight = titleBar ? titleBar.offsetHeight : 0;
-    if (titleBarHeight) titleBar.style.transform = 'translateY(' + headerHeight + 'px)';
+    // The search row (.container-fluid) slides away; the title bar and navbar shell stay fixed, so no
+    // counter-transform is needed on #wcoTitleBar — it simply remains at the top of the viewport
+    const containerFluidHeight = parseFloat(getComputedStyle(containerFluid).height);
     if (params.hideToolbars === true) { // Only hide footer if requested
         footer.style.transform = 'translateY(' + footerHeight + 'px)';
     }
-    // With the title bar left behind, the article starts below it rather than at the top of the window,
-    // so it slides up that much less and has that much less room to fill
+    containerFluid.style.transform = 'translateY(-' + containerFluidHeight + 'px)';
+    articleElement.style.transform = 'translateY(-' + containerFluidHeight + 'px)';
     articleContainer.style.height = window.innerHeight - titleBarHeight + 'px';
-    // articleContainer.style.height = document.documentElement.clientHeight + 'px';
-    header.style.transform = 'translateY(-' + headerHeight + 'px)';
-    articleElement.style.transform = 'translateY(-' + (headerHeight - titleBarHeight) + 'px)';
     // Needed by IE11 (only browser that has window.navigator.msSaveBlob)
-    if (window.navigator && window.navigator.msSaveBlob) articleContainer.style.transform = 'translateY(-' + (headerHeight - titleBarHeight) + 'px)';
+    if (window.navigator && window.navigator.msSaveBlob) articleContainer.style.transform = 'translateY(-' + containerFluidHeight + 'px)';
+    appstate.toolbarVisible = false;
 }
 
 /**
@@ -82,15 +76,15 @@ function showSlidingUIElements () {
     const articleElement = document.querySelector('article');
     const headerStyles = getComputedStyle(document.getElementById('top'));
     const headerHeight = parseFloat(headerStyles.height) + parseFloat(headerStyles.marginBottom);
-    header.style.transform = 'translateY(0)';
-    // The title bar travels back up with the header, so it no longer needs to be held down
-    if (titleBar) titleBar.style.transform = '';
+    // The search row slides back down into place; the title bar and navbar shell never moved, so there
+    // is nothing to release on #wcoTitleBar
+    containerFluid.style.transform = '';
     // Needed for Windows Mobile to prevent header disappearing beneath iframe
     articleElement.style.transform = 'translateY(-1px)';
     articleContainer.style.transform = 'translateY(-1px)';
     footer.style.transform = 'translateY(0)';
     articleContainer.style.height = window.innerHeight + headerHeight + 'px';
-    // articleContainer.style.height = document.documentElement.clientHeight + 'px';
+    appstate.toolbarVisible = true;
 }
 
 let scrollThrottle = false;
@@ -154,7 +148,7 @@ let windowIsScrollable = false;
 function slideAway (e) {
     const newScrollY = articleContainer.contentWindow.pageYOffset;
     let delta;
-    const visibleState = /\(0p?x?\)/.test(header.style.transform);
+    const visibleState = appstate.toolbarVisible;
     // Remove any content warning
     hideActiveContentWarning();
     // If the search field is focused and elements are not showing, do not slide away


### PR DESCRIPTION
### Summary

  Slide `#navbar .container-fluid` instead of the whole header (`#top`), so `#wcoTitleBar` (the emulated window-controls title bar)
  never moves and needs no counter-transform. Replace the fragile regex-based parsing of the inline transform string with an
  explicit `appstate.toolbarVisible` flag as the single source of visibility state.

  ### Background

  The slide-away toolbar used to transform the entire `#top` header off-screen. `#wcoTitleBar` lives inside `#top` and must remain
  fixed — it's window chrome and the only grab handle to move the window when toolbars are hidden. The old code held it in place
  with a coordinated counter-transform that relied on three unenforced invariants (identical transition curves, both transforms set
  in the same frame, and two restore paths kept in sync). `#wcoTitleBar` and `.container-fluid` are actually siblings, so
  `#wcoTitleBar` never moves if `.container-fluid` slides alone — the counter-transform (and all its fragile invariants) disappears
  entirely.

  ### Changes

  | File | Change |
  |---|---|
  | `www/js/init.js` | Add `appstate.toolbarVisible = true` — single source of truth for toolbar visibility |
  | `www/css/app.css` | Transition selector: `#top`, `#wcoTitleBar` → `#navbar .container-fluid` |
  | `www/js/lib/uiUtil.js` | `hideSlidingUIElements()` / `showSlidingUIElements()` rewritten to transform `.container-fluid` only;
  `slideAway()` reads the flag instead of regex-testing the inline transform |
  resetting transforms |
  
  ### Blast radius
  
  - Visibility state tracked via `appstate.toolbarVisible` instead of parsing the header's inline `transform` string.
  - Restore paths consolidated: `btnTop` now delegates to `showSlidingUIElements()`, so there's a single path to maintain.
  - Title bar pinning relies on the sibling DOM structure (`#wcoTitleBar` beside `.container-fluid` inside `#navbar`), which holds
  regardless of scroll context.
  
  ### Manual verification
  
  Requires a Chromium WCO environment (installed PWA or Electron) to exercise the `#wcoTitleBar`:
  - Scroll down in an article: the search row slides up; `#wcoTitleBar` stays pinned at the top.
  - `btnTop` while the toolbar is hidden restores it.
  - Smooth transition, no flicker (preserved `z-index: 1` on `#wcoTitleBar`).