### PR TITLE
Tighten eslint semicolon rule and fix missing semicolons

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,8 +8,27 @@ module.exports = {
         ecmaVersion: 'latest',
         sourceType: 'module'
     },
+    ignorePatterns: [
+        // Build output, and packaged copies of the app
+        'dist/',
+        'bld/',
+        'BundleArtifacts/',
+        'AppPackages/',
+        // Third-party or generated bundles that we do not maintain
+        'replayWorker.js',
+        'www/js/katex/',
+        'www/js/lib/*.min.js',
+        'www/js/lib/webpHeroBundle_*.js',
+        'www/js/lib/*-asm.js',
+        'www/js/lib/*-asm.dev.js',
+        'www/js/lib/*-wasm.js',
+        'www/js/lib/*-wasm.dev.js',
+        'www/js/lib/promisePolyfill.js'
+    ],
     rules: {
-        semi: 0,
+        semi: ['error', 'always'],
+        // Many files in this Repo are deliberately saved with a BOM (see scripts/Add-Remove-BOM.ps1)
+        'unicode-bom': 0,
         indent: ['error', 4],
         'dot-notation': 0,
         'no-var': 0,
@@ -24,4 +43,4 @@ module.exports = {
         'no-extend-native': 0,
         'no-global-assign': 0
     }
-}
+};

--- a/main.cjs
+++ b/main.cjs
@@ -328,7 +328,7 @@ if (!gotSingleInstanceLock) {
 // };
 
 app.whenReady().then(() => {
-    server = express()
+    server = express();
 
     // Add security headers
     server.use((req, res, next) => {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -166,7 +166,7 @@ if (process.env.BUILD === 'production') {
             ],
             flatten: false
         })
-    )
+    );
 } else {
     // Normal (Uniminified) build
     config.plugins.push(
@@ -221,7 +221,7 @@ if (process.env.BUILD === 'production') {
             ],
             flatten: false
         })
-    )
+    );
 }
 
 export default config;

--- a/service-worker.js
+++ b/service-worker.js
@@ -564,7 +564,7 @@ function setReplayCollectionAsRoot (prefix, name) {
         main: self.sw.prefix,
         root: self.sw.prefix,
         static: self.sw.staticPrefix
-    }
+    };
     // If we want to be able to get the static data URL directly from the map, we need to replace the keyes, but as this is quite costly (moving a lot of static)
     // data around, we're using another way to get the static data URL from the map in zimitResolver()
     // let newMap = new Map();
@@ -624,7 +624,7 @@ function zimitResolver (event, rqUrl) {
                 if (/\/A\/static\//.test(rqUrl)) {
                     // If the request is for static data from the replayWorker, we should get them from the Worker's cache
                     // DEV: This extracts both wombat.js and wombatWorkers.js from the staticData Map
-                    var staticDataUrl = rqUrl.replace(/^(.*?\/)[^/]+?\.zim\w?\w?\/[AC/]{2,4}(.*)/, '$1$2')
+                    var staticDataUrl = rqUrl.replace(/^(.*?\/)[^/]+?\.zim\w?\w?\/[AC/]{2,4}(.*)/, '$1$2');
                     if (self.sw.staticData) {
                         var staticData = self.sw.staticData.get(staticDataUrl);
                         if (staticData) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vite';
 
 export default defineConfig({
     server: {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -889,7 +889,7 @@ if (typeof Windows !== 'undefined' &&
     var onBackRequested = function (eventArgs) {
         window.history.back();
         eventArgs.handled = true;
-    }
+    };
     Windows.UI.Core.SystemNavigationManager.getForCurrentView()
         .appViewBackButtonVisibility =
         Windows.UI.Core.AppViewBackButtonVisibility.visible;
@@ -1796,7 +1796,7 @@ function setOPFSUI () {
         archiveFilesLabel.style.display = 'none';
         archiveFileLabel.classList.remove('col-xs-6');
         archiveFileLabel.classList.add('col-xs-12');
-        archiveFileLabel.innerHTML = '<p><b>Select file(s) to add to OPFS</b>:</p>'
+        archiveFileLabel.innerHTML = '<p><b>Select file(s) to add to OPFS</b>:</p>';
         archiveFile.value = 'Add file(s)';
         archiveFile.title = 'Select a single file or multiple files to add to the Origin Private File System. In total, they must not exceed the estimated quota displayed in the OPFS quota panel.';
         archiveFileCol.classList.remove('col-xs-6');
@@ -1827,7 +1827,7 @@ function setOPFSUI () {
             archiveFileLabel.innerHTML = '<p><b>Pick a single unsplit archive</b>:</p>';
             archiveFileLabel.classList.remove('col-xs-12');
             archiveFileLabel.classList.add('col-xs-6');
-            archiveFile.title = 'Select a single file from your device\'s storage. For split or multiple files, place the files in a directory and use the "Select folder" button instead.'
+            archiveFile.title = 'Select a single file from your device\'s storage. For split or multiple files, place the files in a directory and use the "Select folder" button instead.';
             archiveFile.value = 'Select file';
         }
         OPFSQuota.style.display = 'none';
@@ -1908,7 +1908,7 @@ document.getElementById('btnRefresh').addEventListener('click', function () {
         processNativeDirHandle(params.pickedFolder);
         if (params.useOPFS) cache.populateOPFSStorageQuota();
     } else if (typeof Windows !== 'undefined') {
-        scanUWPFolderforArchives(params.pickedFolder)
+        scanUWPFolderforArchives(params.pickedFolder);
     } else if (window.fs) {
         scanNodeFolderforArchives(params.pickedFolder);
     } else if (params.webkitdirectory) {
@@ -2346,7 +2346,7 @@ document.getElementById('lockDisplayOrientationDrop').addEventListener('change',
 });
 document.getElementById('debugLibzimASMDrop').addEventListener('change', function (event) {
     var that = this;
-    var message = '<p>App will reload to apply the new setting.</p>'
+    var message = '<p>App will reload to apply the new setting.</p>';
     if (event.target.value) {
         message += '<p><i>Please be aware that leaving this override setting on can have anomalous effects, ' +
         'e.g. the app will no longer check whether the OS supports full-text searching and searches may fail silently.</i></p>';
@@ -2909,7 +2909,7 @@ function switchCSSTheme () {
                 resizeEvent.initEvent('resize', true, true);
                 window.dispatchEvent(resizeEvent);
             }
-        }
+        };
         doc.head.appendChild(link);
         if (doc.defaultView.DarkReader) {
             doc.defaultView.DarkReader.disable();
@@ -2932,7 +2932,7 @@ function switchCSSTheme () {
                             window.dispatchEvent(resizeEvent);
                         }, 350);
                     }
-                }
+                };
                 darkReader.type = 'text/javascript';
                 darkReader.src = locationPrefix + '/js/lib/darkreader.min.js';
                 doc.head.appendChild(darkReader);
@@ -3026,7 +3026,7 @@ document.querySelectorAll('input[name=cssInjectionMode]').forEach(function (elem
             // We have to reload the article to respect user's choice
             params.themeChanged = true;
             setTab();
-        }
+        };
         if (!params.cssCache && params.cssSource !== 'auto') {
             uiUtil.systemAlert('Transforming the ZIM style requires the use of locally cached Wikimedia stylesheets, so we need to enable these.',
                 'Warning!', true).then(function (rtn) {
@@ -3327,7 +3327,7 @@ function refreshAPIStatus () {
     if (isMessageChannelAvailable()) {
         messageChannelStatus.textContent = 'MessageChannel API available';
         messageChannelStatus.classList.remove('apiAvailable');
-        messageChannelStatus.classList.remove('apiUnavailable')
+        messageChannelStatus.classList.remove('apiUnavailable');
         messageChannelStatus.classList.add('apiAvailable');
     } else {
         apiPanelClass = 'border-warning';
@@ -3942,7 +3942,7 @@ if (storages !== null && storages.length > 0 ||
                 document.getElementById('hideFileSelectors').style.display = 'inline';
                 document.getElementById('btnConfigure').click();
                 var message = params.packagedFile ? ('The packaged file cannot be found!\nPlease check that it is in the "' + params.archivePath +
-                    '" folder\nor pick a new ZIM file.') : 'The previously picked file cannot be found!\nPlease pick a new ZIM file.'
+                    '" folder\nor pick a new ZIM file.') : 'The previously picked file cannot be found!\nPlease pick a new ZIM file.';
                 setTimeout(function () {
                     uiUtil.systemAlert(message);
                 }, 10);
@@ -4029,7 +4029,7 @@ function populateDropDownListOfArchives (archiveDirectories, displayOnly) {
             // console.debug('Last selected archive: ' + lastSelectedArchive);
             // Attempt to select the corresponding item in the list, if it exists
             var success = false;
-            var arrayOfOptionValues = Array.apply(null, archiveList.options).map(function (el) { return el.text; })
+            var arrayOfOptionValues = Array.apply(null, archiveList.options).map(function (el) { return el.text; });
             // console.debug('Archive list: ' + arrayOfOptionValues);
             if (~arrayOfOptionValues.indexOf(lastSelectedArchive)) {
                 archiveList.value = lastSelectedArchive;
@@ -4951,7 +4951,7 @@ function archiveReadyCallback (archive) {
                 document.getElementById('btnHome').click();
             }
         }
-    }
+    };
     // Set contentInjectionMode to serviceWorker when opening a new archive in case the user switched to Restricted mode/jQuery Mode when opening the previous archive
     if (params.contentInjectionMode === 'jquery') {
         params.contentInjectionMode = settingsStore.getItem('contentInjectionMode');
@@ -5405,7 +5405,7 @@ function showZIMIndex (start, search) {
                             var alphaLabel = document.getElementById('alphaCharTxt').parentNode;
                             var panelBody = util.closest(alphaLabel, '.card-body');
                             if (panelBody && panelBody.style.display === 'none') {
-                                var panelHeading = util.getClosestBack(panelBody, function (el) { return /card-header/.test(el.className) });
+                                var panelHeading = util.getClosestBack(panelBody, function (el) { return /card-header/.test(el.className); });
                                 if (panelHeading) panelHeading.click();
                             }
                             alphaLabel.style.borderColor = 'red';
@@ -5679,7 +5679,7 @@ function readArticle (dirEntry) {
     articleContainer = appstate.target === 'window' ? articleWindow : iframe;
     // We must remove focus from UI elements in order to deselect whichever one was clicked (in both Restricted and SW modes),
     if (!params.isLandingPage && articleContainer.contentWindow) articleContainer.contentWindow.focus();
-    uiUtil.pollSpinner()
+    uiUtil.pollSpinner();
     // Show the spinner with a loading message
     var message = dirEntry.url.match(/(?:^|\/)([^/]{1,13})[^/]*?$/);
     message = message ? message[1] + '...' : '...';
@@ -5860,7 +5860,7 @@ function readArticle (dirEntry) {
                             goToArticle(fileDirEntry.zimitRedirect);
                         } else {
                             if (!data) {
-                                var requestedURL = (dirEntry.zimitRedirect ? dirEntry.zimitRedirect : dirEntry.namespace + '/' + dirEntry.url)
+                                var requestedURL = (dirEntry.zimitRedirect ? dirEntry.zimitRedirect : dirEntry.namespace + '/' + dirEntry.url);
                                 uiUtil.systemAlert(
                                     '<p>The requested page <b>' + requestedURL + '</b> does not appear to be an article!</p>' +
                                     '<p>Try searching for content in the search bar, or type a <b><i>space</i></b> for the ZIM ' +
@@ -6071,7 +6071,7 @@ var unhideArticleContainer = function () {
             }, 100);
         }
     }
-}
+};
 
 /**
  * Applies fixes for Wikimedia ZIMs, including reference marker display fixes
@@ -6987,7 +6987,7 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
             if (wikiLang && /^<img/i.test(blockStart) && !/usemap=|math-fallback-image/i.test(match)) {
                 newBlock = '<a href="https://' + (wikimediaZimFlavour !== 'mdwiki' ? wikiLang + '.' : '') + wikimediaZimFlavour +
                     '.org/wiki/File:' + assetZIMUrlEnc.replace(/^.+\/([^/]+?\.(?:jpe?g|svg|png|gif))[^/]*$/i, '$1') +
-                    '" target="_blank">' + newBlock + '</a>'
+                    '" target="_blank">' + newBlock + '</a>';
             }
             return newBlock;
         });
@@ -7012,7 +7012,7 @@ function displayArticleContentInContainer (dirEntry, htmlArticle) {
                 if (/^<img/i.test(blockStart) && !/usemap=|math-fallback-image/i.test(match)) {
                     newBlock = '<a href="https://' + (wikimediaZimFlavour !== 'mdwiki' ? wikiLang + '.' : '') + wikimediaZimFlavour +
                         '.org/wiki/File:' + assetZIMUrl.replace(/^.+\/([^/]+?\.(?:jpe?g|svg|png|gif))[^/]*$/i, '$1') +
-                        '" target="_blank">' + newBlock + '</a>'
+                        '" target="_blank">' + newBlock + '</a>';
                 }
             }
             return newBlock;
@@ -8312,7 +8312,7 @@ function goToArticle (path, download, contentType, pathEnc) {
                         href: path.replace(/^(C\/)?A\//, ''),
                         target: '_blank'
                     };
-                    uiUtil.warnAndOpenExternalLinkInNewTab(null, anchor)
+                    uiUtil.warnAndOpenExternalLinkInNewTab(null, anchor);
                     setTab();
                 }
             } else {
@@ -8397,7 +8397,7 @@ function goToMainArticle () {
                 params.isLandingPage = true;
                 appstate.selectedArchive.landingPageUrl = dirEntry.namespace + '/' + dirEntry.url;
                 readArticle(dirEntry);
-            }
+            };
             if (dirEntry.redirect) {
                 appstate.selectedArchive.resolveRedirect(dirEntry, setMainPage);
             } else if (/text/.test(dirEntry.getMimetype()) || dirEntry.namespace === 'A') {

--- a/www/js/init.js
+++ b/www/js/init.js
@@ -552,7 +552,7 @@ var webpMachine = false;
         var webpScript = document.createElement('script');
         webpScript.onload = function () {
             webpMachine = new webpHero.WebpMachine();
-        }
+        };
         webpScript.src = 'js/webpHeroBundle_0.0.2.js';
         document.head.appendChild(webpScript);
     }

--- a/www/js/lib/arrayFromPolyfill.js
+++ b/www/js/lib/arrayFromPolyfill.js
@@ -17,7 +17,7 @@
 		if (window.Set && arr instanceof Set) {
 			//we use forEach from Set object
 			arr.forEach(function (v) {
-				k.push(v)
+				k.push(v);
 			});
 			arr = k;
 		}

--- a/www/js/lib/images.js
+++ b/www/js/lib/images.js
@@ -101,7 +101,7 @@ function extractImages (images, callback) {
                 image.style.transition = 'opacity 0.3s ease-in';
                 image.style.opacity = '1';
                 removeEventListener('load', transition);
-            }
+            };
             image.addEventListener('load', transition);
             // Let's remove kiwix-display from the end of the url so that the SW will ask for the image
             image.src = imageUrl.replace(/\?kiwix-display/, '');

--- a/www/js/lib/kiwixServe.js
+++ b/www/js/lib/kiwixServe.js
@@ -1500,7 +1500,7 @@ function requestXhttpData (URL, lang, subj, kiwixDate) {
                                 return cache.deleteOPFSEntry(archiveName);
                             });
                         });
-                    }
+                    };
                     if (megabytes > 1000) {
                         var message = '<p>Do you wish to download the following <b>large</b> archive ' + (params.useOPFS ? 'directly into the Origin Private File System' : 'to the current ZIM folder') +
                             '?</p><ul><li><i>' + archiveName + '</i> (<b>' + megabytes$ + ' MB</b>)</li></ul><p><b><i>If you proceed, do not close the app during the download.</i></b><p>' +

--- a/www/js/lib/popovers.js
+++ b/www/js/lib/popovers.js
@@ -568,7 +568,7 @@ function addEventListenersToPopoverIcons (anchor, popover, doc) {
         anchor.newcontainer = true;
         anchor.click();
         closePopover(popover);
-    }
+    };
     const closeIcon = doc.getElementById('popcloseicon');
     const breakoutIcon = doc.getElementById('popbreakouticon');
     // If the icons are not found, do not add event listeners

--- a/www/js/lib/resetApp.js
+++ b/www/js/lib/resetApp.js
@@ -198,4 +198,4 @@ export default {
     reset: reset,
     reloadApp: reloadApp,
     getCacheNames: getCacheNames
-}
+};

--- a/www/js/lib/transformZimit.js
+++ b/www/js/lib/transformZimit.js
@@ -79,7 +79,7 @@ function getZimitRedirect (dirEntry, data, cns) {
     if (dirEntry.namespace === 'H' || cns === 'C' && /^H\//.test(dirEntry.url)) {
         // We are dealing with a Header redirect, so we need to find the Location: field
         redirect = data.match(/^Location:\s*https?:\/\/([^/]+)(.*)$/m);
-        if (!redirect) redirect = data.match(/^WARC-Target-URI:\s*https?:\/\/([^/]+)(.*)$/m)
+        if (!redirect) redirect = data.match(/^WARC-Target-URI:\s*https?:\/\/([^/]+)(.*)$/m);
         if (redirect && redirect[1]) {
             // Type 1 Zimit ZIMs need intermediary 'A' prefix, since there is no longer any A namespace
             params.zimitPrefix = (cns === 'C' ? 'A/' : '') + redirect[1];
@@ -296,7 +296,7 @@ function transformVideoUrl (url, articleDocument, callback) {
         videoId = videoId ? videoId[1] : null;
         if (!videoId) {
             callback(url);
-            return
+            return;
         };
         var prefix = (cns === 'C' ? cns + '/' : '') + 'H/www.youtube.com/ptracking';
         // Set up regular expression search of URL index (aka fuzzy search)
@@ -304,7 +304,7 @@ function transformVideoUrl (url, articleDocument, callback) {
             rgxPrefix: new RegExp('.*' + videoId, 'i'),
             searchUrlIndex: true,
             size: 1
-        }
+        };
         appstate.selectedArchive.findDirEntriesWithPrefixCaseSensitive(prefix, search, function (dirEntry) {
             if (dirEntry && dirEntry[0] && dirEntry[0].url) {
                 dirEntry = dirEntry[0];
@@ -318,7 +318,7 @@ function transformVideoUrl (url, articleDocument, callback) {
                         rgxPrefix: new RegExp('.*' + (ei ? 'ei=' + ei : '') + (cpn ? '.*cpn=' + cpn : ''), 'i'),
                         searchUrlIndex: true,
                         size: 1
-                    }
+                    };
                     appstate.selectedArchive.findDirEntriesWithPrefixCaseSensitive(prefix, search, function (dirEntry) {
                         if (dirEntry && dirEntry[0] && dirEntry[0].url && !search.found) {
                             dirEntry = dirEntry[0];
@@ -348,7 +348,7 @@ function transformVideoUrl (url, articleDocument, callback) {
                         protocol: 'https:',
                         href: 'https://www.youtube.com/watch?v=' + videoId,
                         type: 'video'
-                    }
+                    };
                     uiUtil.warnAndOpenExternalLinkInNewTab(null, anchor, 'This video is not available offline in this ZIM. To view online, please open the following URL');
                 }
             }

--- a/www/js/lib/uiUtil.js
+++ b/www/js/lib/uiUtil.js
@@ -978,7 +978,7 @@ function systemAlert (message, label, isConfirm, declineConfirmLabel, approveCon
             modal.setAttribute('role', 'dialog');
 
             // Get elements to which we will attach event listeners
-            var modalCloseBtn = document.getElementById(prfx + 'modalCloseBtn')
+            var modalCloseBtn = document.getElementById(prfx + 'modalCloseBtn');
             var declineConfirm = document.getElementById(prfx + 'declineConfirm');
             var closeMessage = document.getElementById(prfx + 'closeMessage');
             var approveConfirm = document.getElementById(prfx + 'approveConfirm');
@@ -1342,7 +1342,7 @@ function setupConfigurationToggles () {
         // Close each heading to begin with, except the first and specials
         var exceptionTest = function (testStr) {
             return /Display\ssize|API\sStatus/i.test(testStr) || /Troubleshooting/i.test(testStr) && !params.appCache;
-        }
+        };
         if (panelNext) panelNextHeading.innerHTML = (exceptionTest(panelNextHeading.innerHTML) ? '▽ ' : '▷ ') + panelNextHeading.innerHTML;
         var icon = exceptionTest(headingText) ? '▽ ' : '▷ ';
         panelHeading.innerHTML = panelHeading.innerHTML.replace(/([▽▷]\s)?/, icon);
@@ -1561,7 +1561,7 @@ function getBrowserLanguage () {
     var language = {
         base: 'en',
         locale: 'GB'
-    }
+    };
     var fullLanguage = navigator.language || navigator.userLanguage;
     if (fullLanguage) {
         language.base = fullLanguage.replace(/-.+$/, '').toLowerCase();

--- a/www/js/lib/updater.js
+++ b/www/js/lib/updater.js
@@ -92,7 +92,7 @@ function getLatestUpdates (callback) {
                 }
                 if (!updateTag) updateTag = matchedRelease[2];
                 if (!updateUrl) updateUrl = releaseFile.replace(/\/download\//, '/tag/').replace(/[^/]+$/, '');
-                updatedReleases.push(releaseFile)
+                updatedReleases.push(releaseFile);
             }
             matchedRelease = regexpMatchGitHubReleases.exec(releases);
         }

--- a/www/js/lib/util.js
+++ b/www/js/lib/util.js
@@ -455,7 +455,7 @@ function Hilitor (node, tag) {
     this.countPartialMatches = function () {
         if (node === undefined || !node) return;
         var matches = matchInner(node.innerHTML, '<' + hiliteTag + '\\b[^>]*class="hilitor"[^>]*>', '</' + hiliteTag + '>', 'gi');
-        if (matches) return matches.length
+        if (matches) return matches.length;
         else return 0;
     };
 
@@ -514,7 +514,7 @@ function Hilitor (node, tag) {
             end++;
         }
         return start + inputWords.length;
-    }
+    };
 
     // recursively apply word highlighting
     this.hiliteWords = function (node) {

--- a/www/js/lib/xzdec_wrapper.js
+++ b/www/js/lib/xzdec_wrapper.js
@@ -213,4 +213,4 @@ Decompressor.prototype._fillInBufferIfNeeded = function() {
 
 export default {
     Decompressor: Decompressor
-}
+};

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -784,7 +784,7 @@ ZIMArchive.prototype.readBinaryFile = function (dirEntry, callback) {
             if (dirEntry.zimitRedirect) {
                 return appstate.selectedArchive.getDirEntryByPath(dirEntry.zimitRedirect).then(function (rd) {
                     return appstate.selectedArchive.readBinaryFile(rd, callback);
-                })
+                });
             }
         } else {
             // DEV: Note that we cannot terminate regex below with $ because there is a (rogue?) mimetype
@@ -813,7 +813,7 @@ ZIMArchive.prototype.getUtf8FromData = function (data) {
         decData = utf8.parse(data);
     }
     return decData;
-}
+};
 
 /**
  * Searches the URL pointer list of Directory Entries by pathname
@@ -882,7 +882,7 @@ ZIMArchive.prototype.getDirEntryByPath = function (path, zimitResolving, origina
                     lc: true, // Make the comparator (e.g. dirEntry.url) lowercase
                     size: 1,
                     found: 0
-                }
+                };
                 return fuzzySearch(path, search);
             } else if (!appstate.isReplayWorkerAvailable) {
                 var newpath = path.replace(/^((?:A|C\/A)\/)[^/]+\/(.+)$/, '$1$2');
@@ -1021,7 +1021,7 @@ ZIMArchive.prototype.setZimitMetadata = function () {
     }).catch(function (e) {
         console.warn('Zimit metadata not found in this archive!', e);
     });
-}
+};
 
 export default {
     ZIMArchive: ZIMArchive

--- a/www/js/lib/zstddec_wrapper.js
+++ b/www/js/lib/zstddec_wrapper.js
@@ -302,4 +302,4 @@ function mallocOrDie(sizeOfData) {
 
 export default {
     Decompressor: Decompressor
-}
+};


### PR DESCRIPTION
This also ignores third-party libraries with missing semicolons.